### PR TITLE
fix: Tailscale icon invisible on dark themes when connected

### DIFF
--- a/tailscale/BarWidget.qml
+++ b/tailscale/BarWidget.qml
@@ -51,10 +51,7 @@ Item {
         pointSize: Style.fontSizeL
         applyUiScale: false
         crossed: !(mainInstance?.tailscaleRunning ?? false)
-        color: {
-          if (mainInstance?.tailscaleRunning ?? false) return Color.mOnPrimary
-          return mouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
-        }
+        color: mouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
         opacity: 1.0
       }
 


### PR DESCRIPTION
## Problem

When Tailscale is connected, the bar widget icon becomes nearly invisible on dark themes.

The icon color for the connected state is set to `Color.mOnPrimary` ([BarWidget.qml L54](https://github.com/noctalia-dev/noctalia-plugins/blob/main/tailscale/BarWidget.qml#L54)), which is the semantic color for text/icons rendered **on top of a primary-colored background** (e.g. filled buttons, badges).

However, the capsule background uses `Style.capsuleColor`, not `Color.mPrimary`. On dark themes this means a dark icon on a dark background — poor contrast and effectively invisible.

When Tailscale is **disconnected**, the icon correctly uses `Color.mOnSurface` and is clearly visible.

## Fix

Simplified the icon color binding to use `Color.mOnSurface` consistently for both connected and disconnected states:

```diff
- color: {
-   if (mainInstance?.tailscaleRunning ?? false) return Color.mOnPrimary
-   return mouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
- }
+ color: mouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
```

This matches the color logic already used by the text elements (IP address, peer count) in the same widget.

## Testing

Verified on Noctalia Shell 4.7.6 with niri 25.11 using a dark theme (Tokyo Night). The icon is now clearly visible in both connected and disconnected states.

## Alternative

If the intent is to visually distinguish the connected state via color, the capsule background could be changed to `Color.mPrimary` when Tailscale is running — that would make `Color.mOnPrimary` correct for the icon. Happy to implement that approach instead if preferred.