### PR TITLE
feat(ntfy-notifications): copy message content on click

### DIFF
--- a/ntfy-notifications/Panel.qml
+++ b/ntfy-notifications/Panel.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import qs.Commons
 import qs.Services.UI
 import qs.Widgets
+import Quickshell
 
 Item {
     id: root
@@ -388,6 +389,13 @@ Item {
                                     wrapMode: Text.Wrap
                                     Layout.fillWidth: true
                                     opacity: messageItem.itemOpacity
+
+                                    TapHandler {
+                                        onTapped: {
+                                            Quickshell.execDetached(["wl-copy", modelData.message.trim()])
+                                            pluginApi.withCurrentScreen(s => pluginApi.closePanel(s))
+                                        }
+                                    }
                                 }
 
                                 // Tags (if present)


### PR DESCRIPTION
This PR adds the small feature that if you click a notification on the notification list, the body of the clicked message will be copied to the clipboard and the panel closes. Sometimes you have errors or other things in there that you want in some other context and before there was no way of copying the contents.