### PR TITLE
feat(niri-screensaver): update to 0.6.1

### DIFF
--- a/niri-screensaver/BarWidget.qml
+++ b/niri-screensaver/BarWidget.qml
@@ -1,7 +1,7 @@
 // BarWidget.qml - status-bar entry for niri-screensaver
 //
-// Click       → launch the screensaver immediately.
-// Right-click → context menu: Trigger / Stop / Open Settings / Toggle enabled.
+// Click       → smart toggle: launch if stopped, stop if already running.
+// Right-click → context menu: Trigger / Stop / Quit / Reload / Toggle / Settings.
 //
 // Renders a custom monitor-with-image SVG (assets/screensaver.svg) recolored
 // at runtime via MultiEffect so it follows the active Noctalia theme. The
@@ -94,11 +94,64 @@ Item {
     killProc.running = true
   }
 
+  // Smart left-click: probe running state, then stop if running else launch.
+  // The probe (`niri-screensaver-launch is-running`) exits 0 when running, so
+  // we branch in onExited. Falling back to launch on a probe error keeps the
+  // click useful even if the status command is somehow unavailable.
+  Process {
+    id: statusProbe
+    onExited: function (code) {
+      if (code === 0) root._runKill()
+      else root._runLaunch()
+    }
+  }
+  function _smartToggle() {
+    var argv = root.mainInstance ? root.mainInstance._statusArgv()
+                                 : ["niri-screensaver-launch", "is-running"]
+    statusProbe.command = argv
+    statusProbe.running = true
+  }
+
+  // Quit: stop the screensaver AND disable it, so Noctalia's idle won't
+  // relaunch it until it's re-enabled (Toggle enabled, or Reload).
+  function _runQuit() {
+    root._runKill()
+    if (root.pluginApi) {
+      root.pluginApi.pluginSettings.enabled = false
+      root.pluginApi.saveSettings()
+    }
+  }
+
+  // Reload: full fresh-start. Stop the screensaver, restart the Noctalia shell
+  // (so the systray reappears), and leave the screensaver enabled. The work runs
+  // detached via setsid because `qs kill` tears down this widget's own host
+  // process — the detached child outlives it and brings the shell back up.
+  Process {
+    id: reloadProc
+    onExited: function (code) {
+      if (code !== 0) Logger.w("NiriScreensaver", "reload (bar) exited with code", code)
+    }
+  }
+  function _runReload() {
+    if (root.pluginApi) {
+      root.pluginApi.pluginSettings.enabled = true
+      root.pluginApi.saveSettings()
+    }
+    reloadProc.command = ["sh", "-c",
+      "setsid sh -c 'niri-screensaver-launch kill; "
+      + "rm -f \"$HOME/.config/niri-screensaver/disabled\"; "
+      + "sleep 0.3; qs kill; sleep 0.6; exec qs -c noctalia-shell' "
+      + "</dev/null >/dev/null 2>&1 &"]
+    reloadProc.running = true
+  }
+
   NPopupContextMenu {
     id: contextMenu
     model: [
       { "label": pluginApi?.tr("barwidget.trigger"),  "action": "trigger",  "icon": "player-play" },
-      { "label": pluginApi?.tr("barwidget.stop"),     "action": "stop",     "icon": "stop" },
+      { "label": pluginApi?.tr("barwidget.stop"),     "action": "stop",     "icon": "player-stop" },
+      { "label": pluginApi?.tr("barwidget.quit"),     "action": "quit",     "icon": "logout" },
+      { "label": pluginApi?.tr("barwidget.reload"),   "action": "reload",   "icon": "refresh" },
       { "label": pluginApi?.tr("barwidget.toggle"),   "action": "toggle",   "icon": "power" },
       { "label": pluginApi?.tr("barwidget.settings"), "action": "settings", "icon": "settings" }
     ]
@@ -110,6 +163,10 @@ Item {
         root._runLaunch()
       } else if (action === "stop") {
         root._runKill()
+      } else if (action === "quit") {
+        root._runQuit()
+      } else if (action === "reload") {
+        root._runReload()
       } else if (action === "toggle") {
         if (root.pluginApi) {
           var en = root.pluginApi.pluginSettings.enabled === true
@@ -146,7 +203,7 @@ Item {
       if (mouse.button === Qt.RightButton) {
         PanelService.showContextMenu(contextMenu, root, screen)
       } else {
-        root._runLaunch()
+        root._smartToggle()
       }
     }
   }

--- a/niri-screensaver/Main.qml
+++ b/niri-screensaver/Main.qml
@@ -98,6 +98,13 @@ Item {
       ["niri-screensaver-launch", "kill"]
     )
   }
+  // Quiet running-state probe for the bar widget's smart left-click toggle:
+  // exit 0 if running, 1 if not. Uses the standard launcher on PATH (a fully
+  // custom launcherCommand is rare and the launcher name is stable), so the
+  // widget can decide whether a click should launch or stop.
+  function _statusArgv() {
+    return ["niri-screensaver-launch", "is-running"]
+  }
 
   // ----- Shell config writer -----
   function _renderShellConfig() {
@@ -122,6 +129,7 @@ Item {
       "DISMISS_ON_KEY=\"" + bool(s.dismissOnKey) + "\"",
       "RANDOM_LOGO=\"" + bool(s.randomLogo) + "\"",
       "LOGO_DIR=\"" + _shEscape(s.logoDir) + "\"",
+      "MULTI_MONITOR_MODE=\"" + _shEscape(s.multiMonitorMode || "independent") + "\"",
       ""
     ].join("\n")
   }

--- a/niri-screensaver/README.md
+++ b/niri-screensaver/README.md
@@ -16,8 +16,13 @@ and rendered in a fullscreen Alacritty surface.
   tears down cleanly when Noctalia's lock fires (avoids burning CPU under the
   lock surface). Only writes to hook slots that are empty or already hold the
   plugin's command — never clobbers a hook you authored manually.
-- **Bar widget**: click to trigger; right-click for stop / toggle enabled /
-  open settings. Recolors to follow the active Noctalia theme.
+- **Bar widget**: left-click is a smart toggle — launches the screensaver if
+  it's stopped, stops it if it's running (via a quiet `niri-screensaver-launch
+  is-running` probe). Right-click opens a menu: **Trigger now**, **Stop**,
+  **Quit** (stop *and* disable so idle won't relaunch it), **Reload** (stop,
+  restart the Noctalia shell so the systray reappears, and re-enable),
+  **Toggle enabled**, and **Open settings**. Recolors to follow the active
+  Noctalia theme.
 - **Settings tab** for idle threshold, effect include/exclude lists,
   fade-in/out **dropdowns** populated from `niri-screensaver-ctl effects`,
   a **logo file dropdown** that auto-refreshes from your logo directory,
@@ -70,6 +75,7 @@ re-syncs the idle hook.
 | Exclude effects (CSV) | text | `EXCLUDE_EFFECTS` | `dev_worm` |
 | Fade-in effect | dropdown | `FADE_IN_EFFECT` | _empty_ |
 | Fade-out effect | dropdown | `FADE_OUT_EFFECT` | _empty_ |
+| Multi-monitor mode | dropdown | `MULTI_MONITOR_MODE` | `independent` |
 | Show clock between effects | toggle | `SHOW_CLOCK` | `false` |
 | Clock format (strftime) | text | `CLOCK_FORMAT` | `%H:%M` |
 | Show now-playing track | toggle | `SHOW_NOW_PLAYING` | `false` |

--- a/niri-screensaver/Settings.qml
+++ b/niri-screensaver/Settings.qml
@@ -34,6 +34,7 @@ ColumnLayout {
   property string editFadeOutEffect:  cfg.fadeOutEffect  ?? defaults.fadeOutEffect  ?? ""
   property bool   editRandomLogo:     cfg.randomLogo     ?? defaults.randomLogo     ?? false
   property string editLogoDir:        cfg.logoDir        ?? defaults.logoDir        ?? ""
+  property string editMultiMonitorMode: cfg.multiMonitorMode ?? defaults.multiMonitorMode ?? "independent"
   property string editLogoPath:       cfg.logoPath       ?? defaults.logoPath       ?? ""
 
   // Effective logo directory for the file dropdown: user override wins, otherwise
@@ -67,6 +68,7 @@ ColumnLayout {
     pluginApi.pluginSettings.fadeOutEffect  = root.editFadeOutEffect
     pluginApi.pluginSettings.randomLogo     = root.editRandomLogo
     pluginApi.pluginSettings.logoDir        = root.editLogoDir
+    pluginApi.pluginSettings.multiMonitorMode = root.editMultiMonitorMode
     pluginApi.pluginSettings.logoPath       = root.editLogoPath
     pluginApi.pluginSettings.showClock      = root.editShowClock
     pluginApi.pluginSettings.clockFormat    = root.editClockFormat
@@ -308,6 +310,17 @@ ColumnLayout {
         defaultValue: root.defaults.fadeOutEffect
         onSelected: key => root.editFadeOutEffect = key
       }
+
+      NComboBox {
+        Layout.fillWidth: true
+        minimumWidth: 280
+        label: pluginApi?.tr("settings.multi-monitor")
+        description: pluginApi?.tr("settings.multi-monitor-desc")
+        model: multiMonitorOptions
+        currentKey: root.editMultiMonitorMode
+        defaultValue: root.defaults.multiMonitorMode
+        onSelected: key => root.editMultiMonitorMode = key
+      }
     }
   }
 
@@ -478,6 +491,11 @@ ColumnLayout {
 
   ListModel { id: effectOptions }
 
+  // Fixed two-option model for the multi-monitor mode dropdown. Populated in
+  // Component.onCompleted so the names can come from i18n (ListElement can't
+  // call tr() at declaration time).
+  ListModel { id: multiMonitorOptions }
+
   // ---- Logo file dropdown plumbing ----
   //
   // Detect the installed share/logos/ at startup by mirroring the bash
@@ -537,6 +555,9 @@ ColumnLayout {
       'for d in "$HOME/.local/share/niri-screensaver/logos" "/usr/share/niri-screensaver/logos"; do [ -d "$d" ] && echo "$d" && exit 0; done']
     logoDirDetectProcess.running = true
     _rebuildLogoOptions()
+
+    multiMonitorOptions.append({key: "independent", name: pluginApi?.tr("settings.multi-monitor-independent")})
+    multiMonitorOptions.append({key: "mirror", name: pluginApi?.tr("settings.multi-monitor-mirror")})
 
     // Seed the "(none)" entry so the comboboxes have something to show
     // before the effects-detection Process returns.

--- a/niri-screensaver/i18n/en.json
+++ b/niri-screensaver/i18n/en.json
@@ -29,6 +29,11 @@
     "fade-out-desc": "Optional one-shot effect played when the screensaver dismisses.",
     "effect-none": "(none)",
 
+    "multi-monitor": "Multi-monitor mode",
+    "multi-monitor-desc": "With more than one display: Independent shows a different random effect per monitor; Mirror shows the same effect on all of them (best on matched resolutions).",
+    "multi-monitor-independent": "Independent (different per monitor)",
+    "multi-monitor-mirror": "Mirror (same on all monitors)",
+
     "logo-section": "Logo",
     "random-logo": "Random logo per cycle",
     "random-logo-desc": "Pick a different logo from the Logo directory before each effect cycle.",
@@ -68,6 +73,8 @@
     "tooltip": "Niri Screensaver",
     "trigger": "Trigger now",
     "stop": "Stop",
+    "quit": "Quit (stop & disable)",
+    "reload": "Reload shell",
     "toggle": "Toggle enabled",
     "settings": "Open settings"
   }

--- a/niri-screensaver/manifest.json
+++ b/niri-screensaver/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "niri-screensaver",
   "name": "Niri Screensaver",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "minNoctaliaVersion": "4.7.0",
   "author": "jfreed-dev",
   "license": "GPL-3.0-only",

--- a/niri-screensaver/manifest.json
+++ b/niri-screensaver/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "niri-screensaver",
   "name": "Niri Screensaver",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "minNoctaliaVersion": "4.7.0",
   "author": "jfreed-dev",
   "license": "GPL-3.0-only",
@@ -37,6 +37,7 @@
       "dismissOnKey": true,
       "randomLogo": false,
       "logoDir": "",
+      "multiMonitorMode": "independent",
       "launcherCommand": "niri-screensaver-launch launch",
       "killCommand": "niri-screensaver-launch kill"
     }


### PR DESCRIPTION
Updates the **niri-screensaver** plugin to upstream release [v0.6.1](https://github.com/jfreed-dev/niri-screensaver/releases/tag/v0.6.1). The registry currently carries 0.5.9.

### What's new since 0.5.9
- **Multi-monitor mode** dropdown (independent / mirror) in Settings — mirror shows the same effect on every output.
- **Bar widget controls**: left-click is a smart toggle (launch/stop); right-click menu gains **Quit** (stop + disable) and **Reload**.
- Multi-monitor `focus-follows-mouse` fixes (surfaces pin to the correct output; dismissing one screen wakes all).
- 0.6.1 is a test/docs release (bats unit suite + kcov coverage); **no plugin-surface changes** — the only plugin diff vs 0.6.0 is the manifest version string.

### Changes here
- Synced `niri-screensaver/` plugin source to 0.6.1 (manifest, Settings.qml, BarWidget.qml, Main.qml, i18n, README).

`settings.json` excluded; JSON validated. `registry.json` intentionally untouched (auto-generated post-merge).