### PR TITLE
feat(niri-screensaver): update to 0.7.0

### DIFF
--- a/niri-screensaver/manifest.json
+++ b/niri-screensaver/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "niri-screensaver",
   "name": "Niri Screensaver",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "minNoctaliaVersion": "4.7.0",
   "author": "jfreed-dev",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
Updates the `niri-screensaver` plugin to **0.7.0** ([upstream release](https://github.com/jfreed-dev/niri-screensaver/releases/tag/v0.7.0)). Follows the merged 0.6.1 update (#910).

**Plugin-surface diff is just the manifest version string (0.6.1 → 0.7.0).** The 0.7.0 release is CLI-side: mirror mode now auto-fits the shared `tte` canvas to the smallest output for byte-identical frames on mismatched-resolution monitors, with no config (the `MIRROR_CANVAS_COLS/ROWS` override remains). No QML, settings, i18n, or asset changes.

`registry.json` is intentionally untouched (auto-generated post-merge).