### PR TITLE
Feature(ThinkPad - Fan & Thermal Control): Add configurable status colors and translation improvements

### DIFF
--- a/thinkpad-fan/BarWidget.qml
+++ b/thinkpad-fan/BarWidget.qml
@@ -23,8 +23,17 @@ Item {
     readonly property real barFontSize: Style.getBarFontSizeForScreen(root.screenName)
     readonly property string fixedFont: Settings.data.ui.fontFixed
 
+    // Special fan level identifiers as reported by /proc/acpi/ibm/fan
+    readonly property string levelAuto: "auto"
+    readonly property string levelOff: "0"
+    readonly property string levelUnknown: "unknown"
+
+    // procfs/sysfs don't emit inotify events — values must be polled
+    readonly property int pollIntervalMs: 2000
+    readonly property int refreshDelayMs: 300
+
     property int fanRpm: 0
-    property string fanLevel: "auto"
+    property string fanLevel: levelAuto
     property int currentTemp: 0
     property bool isInitialized: false
 
@@ -38,6 +47,18 @@ Item {
         pluginApi?.pluginSettings?.allowPopupOpening ??
         pluginApi?.manifest?.metadata?.defaultSettings?.allowPopupOpening ??
         true
+
+    // Color used when the fan is off (Level 0)
+    readonly property string colorLevel0:
+        pluginApi?.pluginSettings?.colorLevel0 ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorLevel0 ??
+        Color.mError
+
+    // Color used when the fan runs at a forced speed (any mode except auto/off)
+    readonly property string colorActive:
+        pluginApi?.pluginSettings?.colorActive ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorActive ??
+        Color.mPrimary
 
     readonly property real contentWidth: layout.implicitWidth + Style.marginS * 2
     readonly property real contentHeight: capsuleHeight
@@ -62,7 +83,7 @@ Item {
             if (content) {
                 let lines = content.split("\n");
                 let parsedRpm = 0;
-                let parsedLevel = "auto";
+                let parsedLevel = root.levelAuto;
 
                 for (let i = 0; i < lines.length; i++) {
                     let line = lines[i].trim();
@@ -112,7 +133,7 @@ Item {
         }
 
         let cleanLevel = String(targetLevel).replace(/[\r\n\t]/g, "").trim().toLowerCase();
-        if (!cleanLevel || cleanLevel === "unknown") {
+        if (!cleanLevel || cleanLevel === root.levelUnknown) {
             return;
         }
 
@@ -122,11 +143,10 @@ Item {
         fanProcess.running = true;
     }
 
-    Timer { id: refreshTimer; interval: 300; repeat: false; onTriggered: { fanLoader.reload(); tempLoader.reload(); } }
-    // procfs/sysfs don't emit inotify events — polling is required for live values
-    Timer { interval: 2000; running: true; repeat: true; triggeredOnStart: true; onTriggered: { fanLoader.reload(); tempLoader.reload(); } }
+    Timer { id: refreshTimer; interval: root.refreshDelayMs; repeat: false; onTriggered: { fanLoader.reload(); tempLoader.reload(); } }
+    Timer { interval: root.pollIntervalMs; running: true; repeat: true; triggeredOnStart: true; onTriggered: { fanLoader.reload(); tempLoader.reload(); } }
 
-    readonly property bool isCustomActive: root.fanLevel !== "auto" && root.fanLevel !== "0"
+    readonly property bool isCustomActive: root.fanLevel !== root.levelAuto && root.fanLevel !== root.levelOff
 
     // ===== NATIVE NOCTALIA CONTEXT MENU =====
     NPopupContextMenu {
@@ -134,7 +154,7 @@ Item {
 
         model: [
             {
-                "label": "Widget Settings",
+                "label": pluginApi?.tr("menu.widget-settings"),
                 "action": "settings",
                 "icon": "settings"
             }
@@ -163,14 +183,14 @@ Item {
         color: !root.colorizeByStatus
             ? Style.capsuleColor
             : (root.isCustomActive
-                ? Color.mPrimary
-                : (root.fanLevel === "0" ? "#cc241d" : Style.capsuleColor))
+                ? root.colorActive
+                : (root.fanLevel === root.levelOff ? root.colorLevel0 : Style.capsuleColor))
 
         border.color: !root.colorizeByStatus
             ? Style.capsuleBorderColor
             : (root.isCustomActive
-                ? Color.mPrimary
-                : (root.fanLevel === "0" ? "#cc241d" : Style.capsuleBorderColor))
+                ? root.colorActive
+                : (root.fanLevel === root.levelOff ? root.colorLevel0 : Style.capsuleBorderColor))
         border.width: Style.capsuleBorderWidth
 
         RowLayout {
@@ -181,7 +201,7 @@ Item {
             NIcon {
                 id: fanIcon
                 icon: "car-fan"
-                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === "0") ? Color.mOnPrimary : Color.mOnSurface
+                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === root.levelOff) ? Color.mOnPrimary : Color.mOnSurface
             }
 
             NText {
@@ -190,7 +210,7 @@ Item {
                 pointSize: barFontSize
                 font.family: root.fixedFont
                 font.weight: Font.Bold
-                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === "0") ? Color.mOnPrimary : Color.mOnSurface
+                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === root.levelOff) ? Color.mOnPrimary : Color.mOnSurface
             }
         }
     }

--- a/thinkpad-fan/BarWidget.qml
+++ b/thinkpad-fan/BarWidget.qml
@@ -48,17 +48,28 @@ Item {
         pluginApi?.manifest?.metadata?.defaultSettings?.allowPopupOpening ??
         true
 
-    // Color used when the fan is off (Level 0)
-    readonly property string colorLevel0:
+    // Per-mode colors. An empty value means "neutral" (match the bar): off and
+    // forced-speed default to a theme color, automatic defaults to neutral.
+    readonly property var rawColorLevel0:
         pluginApi?.pluginSettings?.colorLevel0 ??
         pluginApi?.manifest?.metadata?.defaultSettings?.colorLevel0 ??
         Color.mError
-
-    // Color used when the fan runs at a forced speed (any mode except auto/off)
-    readonly property string colorActive:
+    readonly property var rawColorActive:
         pluginApi?.pluginSettings?.colorActive ??
         pluginApi?.manifest?.metadata?.defaultSettings?.colorActive ??
         Color.mPrimary
+    readonly property var rawColorAuto:
+        pluginApi?.pluginSettings?.colorAuto ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorAuto ??
+        ""
+
+    readonly property bool level0IsNeutral: String(rawColorLevel0).length === 0
+    readonly property bool activeIsNeutral: String(rawColorActive).length === 0
+    readonly property bool autoIsNeutral: String(rawColorAuto).length === 0
+
+    readonly property string colorLevel0: level0IsNeutral ? Style.capsuleColor : rawColorLevel0
+    readonly property string colorActive: activeIsNeutral ? Style.capsuleColor : rawColorActive
+    readonly property string colorAuto: autoIsNeutral ? Style.capsuleColor : rawColorAuto
 
     readonly property real contentWidth: layout.implicitWidth + Style.marginS * 2
     readonly property real contentHeight: capsuleHeight
@@ -147,6 +158,16 @@ Item {
     Timer { interval: root.pollIntervalMs; running: true; repeat: true; triggeredOnStart: true; onTriggered: { fanLoader.reload(); tempLoader.reload(); } }
 
     readonly property bool isCustomActive: root.fanLevel !== root.levelAuto && root.fanLevel !== root.levelOff
+    readonly property bool isOff: root.fanLevel === root.levelOff
+
+    // Resolved color + neutral flag for the currently active fan mode
+    readonly property bool currentIsNeutral:
+        !root.colorizeByStatus
+        || (root.isCustomActive ? root.activeIsNeutral
+            : (root.isOff ? root.level0IsNeutral : root.autoIsNeutral))
+    readonly property string currentColor:
+        root.isCustomActive ? root.colorActive
+        : (root.isOff ? root.colorLevel0 : root.colorAuto)
 
     // ===== NATIVE NOCTALIA CONTEXT MENU =====
     NPopupContextMenu {
@@ -180,17 +201,8 @@ Item {
         height: root.contentHeight
         radius: Style.radiusL
         
-        color: !root.colorizeByStatus
-            ? Style.capsuleColor
-            : (root.isCustomActive
-                ? root.colorActive
-                : (root.fanLevel === root.levelOff ? root.colorLevel0 : Style.capsuleColor))
-
-        border.color: !root.colorizeByStatus
-            ? Style.capsuleBorderColor
-            : (root.isCustomActive
-                ? root.colorActive
-                : (root.fanLevel === root.levelOff ? root.colorLevel0 : Style.capsuleBorderColor))
+        color: root.currentIsNeutral ? Style.capsuleColor : root.currentColor
+        border.color: root.currentIsNeutral ? Style.capsuleBorderColor : root.currentColor
         border.width: Style.capsuleBorderWidth
 
         RowLayout {
@@ -201,7 +213,7 @@ Item {
             NIcon {
                 id: fanIcon
                 icon: "car-fan"
-                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === root.levelOff) ? Color.mOnPrimary : Color.mOnSurface
+                color: root.currentIsNeutral ? Color.mOnSurface : Color.mOnPrimary
             }
 
             NText {
@@ -210,7 +222,7 @@ Item {
                 pointSize: barFontSize
                 font.family: root.fixedFont
                 font.weight: Font.Bold
-                color: root.colorizeByStatus && (root.isCustomActive || root.fanLevel === root.levelOff) ? Color.mOnPrimary : Color.mOnSurface
+                color: root.currentIsNeutral ? Color.mOnSurface : Color.mOnPrimary
             }
         }
     }

--- a/thinkpad-fan/FanPopup.qml
+++ b/thinkpad-fan/FanPopup.qml
@@ -93,7 +93,11 @@ Item {
             anchors.fill: parent
             radius: Style.radiusS
             color: parent.isSelected
-                ? (parent.level === "0" ? "#cc241d" : Color.mPrimary)
+                ? (parent.level === (root.mainWidget?.levelOff ?? "0")
+                    ? (root.mainWidget?.colorLevel0 ?? Color.mError)
+                    : (parent.level === (root.mainWidget?.levelAuto ?? "auto")
+                        ? Style.capsuleColor
+                        : (root.mainWidget?.colorActive ?? Color.mPrimary)))
                 : Color.mSurface
             opacity: parent.isSelected ? 1.0 : (parent.containsMouse ? 0.85 : 0.5)
         }
@@ -103,7 +107,7 @@ Item {
             text: parent.text
             font.weight: parent.isSelected ? Font.Bold : Font.Normal
             pointSize: Style.fontSizeS
-            color: parent.isSelected ? Color.mOnPrimary : Color.mOnSurface
+            color: (parent.isSelected && parent.level !== (root.mainWidget?.levelAuto ?? "auto")) ? Color.mOnPrimary : Color.mOnSurface
         }
     }
 }

--- a/thinkpad-fan/FanPopup.qml
+++ b/thinkpad-fan/FanPopup.qml
@@ -77,7 +77,17 @@ Item {
         property string level: ""
         
         readonly property bool isSelected: root.mainWidget?.fanLevel === level
-       
+
+        // Resolved color + neutral flag for the mode this button represents
+        readonly property bool stateNeutral:
+            level === (root.mainWidget?.levelOff ?? "0") ? (root.mainWidget?.level0IsNeutral ?? false)
+            : level === (root.mainWidget?.levelAuto ?? "auto") ? (root.mainWidget?.autoIsNeutral ?? true)
+            : (root.mainWidget?.activeIsNeutral ?? false)
+        readonly property string stateColor:
+            level === (root.mainWidget?.levelOff ?? "0") ? (root.mainWidget?.colorLevel0 ?? Color.mError)
+            : level === (root.mainWidget?.levelAuto ?? "auto") ? (root.mainWidget?.colorAuto ?? Style.capsuleColor)
+            : (root.mainWidget?.colorActive ?? Color.mPrimary)
+
         implicitWidth: 52 * Style.uiScaleRatio
         implicitHeight: 28 * Style.uiScaleRatio
         cursorShape: Qt.PointingHandCursor
@@ -92,13 +102,7 @@ Item {
         Rectangle {
             anchors.fill: parent
             radius: Style.radiusS
-            color: parent.isSelected
-                ? (parent.level === (root.mainWidget?.levelOff ?? "0")
-                    ? (root.mainWidget?.colorLevel0 ?? Color.mError)
-                    : (parent.level === (root.mainWidget?.levelAuto ?? "auto")
-                        ? Style.capsuleColor
-                        : (root.mainWidget?.colorActive ?? Color.mPrimary)))
-                : Color.mSurface
+            color: parent.isSelected ? parent.stateColor : Color.mSurface
             opacity: parent.isSelected ? 1.0 : (parent.containsMouse ? 0.85 : 0.5)
         }
 
@@ -107,7 +111,7 @@ Item {
             text: parent.text
             font.weight: parent.isSelected ? Font.Bold : Font.Normal
             pointSize: Style.fontSizeS
-            color: (parent.isSelected && parent.level !== (root.mainWidget?.levelAuto ?? "auto")) ? Color.mOnPrimary : Color.mOnSurface
+            color: (parent.isSelected && !parent.stateNeutral) ? Color.mOnPrimary : Color.mOnSurface
         }
     }
 }

--- a/thinkpad-fan/README.md
+++ b/thinkpad-fan/README.md
@@ -7,9 +7,21 @@ A resilient system utility plugin designed for the **Noctalia** desktop shell en
 
 *   **Dynamic Fan Speed Indicator**: Embedded status bar module reporting realtime revolutions per minute (`RPM`) telemetry, updating cycles safely every 2 seconds.
 *   **Thermal Zone Inspector**: Contextual diagnostic popup panel tracking active primary sensor clusters.
-*   **Stateful Micro-Pill Alerts**: Custom visual states that color-shift dynamically based on active overrides:
-    *   Turns **Solid Crimson Red** if safety limits are bypassed by forcing the fans off (`level 0`).
-    *   Shifts to system `mPrimary` palette states when explicit constant numeric thresholds are locked down.
+*   **Stateful Micro-Pill Alerts**: The bar capsule color-shifts based on the current fan mode (when *Dynamic coloring* is enabled):
+    *   **Fan off (`level 0`)**: uses the configurable *Fan off* color (defaults to the theme `mError`).
+    *   **Automatic mode**: stays neutral, matching the rest of the bar.
+    *   **Any forced speed** (levels `1`–`7`, full speed, …): uses the configurable *Fan active* color (defaults to the theme `mPrimary`).
+*   **Configurable Colors**: Both the *Fan off* and *Fan active* colors are pickable from the theme palette in the plugin settings.
+
+## Settings
+--------
+
+Open the plugin settings (right-click the widget → **Widget Settings**) to configure:
+
+*   **Dynamic coloring**: toggle the mode-based capsule coloring on/off. When off, the capsule keeps the default bar color.
+    *   **Fan off color**: palette color used when the fan is stopped (`level 0`).
+    *   **Fan active color**: palette color used whenever the fan runs at a forced speed (every mode except automatic and off).
+*   **Fan speed manual override**: when enabled, left-clicking the widget opens the manual fan control panel.
 
 ## Prerequisites
 -------------

--- a/thinkpad-fan/README.md
+++ b/thinkpad-fan/README.md
@@ -9,9 +9,9 @@ A resilient system utility plugin designed for the **Noctalia** desktop shell en
 *   **Thermal Zone Inspector**: Contextual diagnostic popup panel tracking active primary sensor clusters.
 *   **Stateful Micro-Pill Alerts**: The bar capsule color-shifts based on the current fan mode (when *Dynamic coloring* is enabled):
     *   **Fan off (`level 0`)**: uses the configurable *Fan off* color (defaults to the theme `mError`).
-    *   **Automatic mode**: stays neutral, matching the rest of the bar.
+    *   **Automatic mode**: neutral by default, matching the rest of the bar — optionally a custom *Automatic mode* color can be chosen.
     *   **Any forced speed** (levels `1`–`7`, full speed, …): uses the configurable *Fan active* color (defaults to the theme `mPrimary`).
-*   **Configurable Colors**: Both the *Fan off* and *Fan active* colors are pickable from the theme palette in the plugin settings.
+*   **Configurable Colors**: The *Fan off*, *Fan active* and *Automatic mode* colors are pickable from the theme palette in the plugin settings — each can also be set to **neutral** (no color) to match the bar.
 
 ## Settings
 --------
@@ -21,6 +21,8 @@ Open the plugin settings (right-click the widget → **Widget Settings**) to con
 *   **Dynamic coloring**: toggle the mode-based capsule coloring on/off. When off, the capsule keeps the default bar color.
     *   **Fan off color**: palette color used when the fan is stopped (`level 0`).
     *   **Fan active color**: palette color used whenever the fan runs at a forced speed (every mode except automatic and off).
+    *   **Automatic mode color**: palette color for automatic mode (neutral by default).
+    *   Each of the three pickers includes a **neutral** (no-color) option as the first swatch — choose it to keep that mode matching the bar.
 *   **Fan speed manual override**: when enabled, left-clicking the widget opens the manual fan control panel.
 
 ## Prerequisites

--- a/thinkpad-fan/SettingsView.qml
+++ b/thinkpad-fan/SettingsView.qml
@@ -30,6 +30,12 @@ ColumnLayout {
         pluginApi?.manifest?.metadata?.defaultSettings?.colorActive ??
         Color.mPrimary
 
+    // Empty = unset → automatic mode stays neutral
+    property string editColorAuto:
+        pluginApi?.pluginSettings?.colorAuto ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorAuto ??
+        ""
+
     // ===== SAVE =====
     function saveSettings() {
         if (!pluginApi) return
@@ -37,6 +43,7 @@ ColumnLayout {
         pluginApi.pluginSettings.allowPopupOpening = root.editAllowPopupOpening
         pluginApi.pluginSettings.colorActive = root.editColorActive
         pluginApi.pluginSettings.colorLevel0 = root.editColorLevel0
+        pluginApi.pluginSettings.colorAuto = root.editColorAuto
         pluginApi.saveSettings()
     }
 
@@ -52,6 +59,56 @@ ColumnLayout {
         Color.mPrimary, Color.mSecondary, Color.mTertiary, Color.mError,
         Color.mSurface, Color.mSurfaceVariant, Color.mOutline
     ]
+
+    // Reusable palette picker: a "neutral" (no-color) swatch followed by the theme palette.
+    // `selected` is the current value (empty = neutral); `picked` fires with the chosen value.
+    component ColorSwatchRow: RowLayout {
+        id: swatchRow
+        property string selected: ""
+        signal picked(string value)
+        spacing: Style.marginS
+
+        // Neutral / no-color option
+        Rectangle {
+            width: root.swatchSize
+            height: root.swatchSize
+            radius: root.swatchSize / 2
+            color: Style.capsuleColor
+            border.color: !swatchRow.selected ? Color.mOnSurface : Color.mOutline
+            border.width: !swatchRow.selected ? root.swatchBorderSelected : root.swatchBorderDefault
+
+            NIcon {
+                anchors.centerIn: parent
+                icon: "close"
+                color: Color.mOnSurfaceVariant
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: swatchRow.picked("")
+            }
+        }
+
+        Repeater {
+            model: root.noctaliaPalette
+
+            Rectangle {
+                width: root.swatchSize
+                height: root.swatchSize
+                radius: root.swatchSize / 2
+                color: modelData
+                border.color: (swatchRow.selected && Qt.colorEqual(swatchRow.selected, modelData)) ? Color.mOnSurface : Color.mOutline
+                border.width: (swatchRow.selected && Qt.colorEqual(swatchRow.selected, modelData)) ? root.swatchBorderSelected : root.swatchBorderDefault
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: swatchRow.picked(String(modelData))
+                }
+            }
+        }
+    }
 
     // Option 1: Dynamic coloring based on fan status
     NToggle {
@@ -86,30 +143,11 @@ ColumnLayout {
                 color: Color.mOnSurfaceVariant
             }
 
-            RowLayout {
-                spacing: Style.marginS
-
-                Repeater {
-                    id: level0Color
-                    model: root.noctaliaPalette
-
-                    Rectangle {
-                        width: root.swatchSize
-                        height: root.swatchSize
-                        radius: root.swatchSize / 2
-                        color: modelData
-                        border.color: (root.editColorLevel0 && Qt.colorEqual(root.editColorLevel0, modelData)) ? Color.mOnSurface : Color.mOutline
-                        border.width: (root.editColorLevel0 && Qt.colorEqual(root.editColorLevel0, modelData)) ? root.swatchBorderSelected : root.swatchBorderDefault
-
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                root.editColorLevel0 = modelData
-                                root.saveSettings()
-                            }
-                        }
-                    }
+            ColorSwatchRow {
+                selected: root.editColorLevel0
+                onPicked: value => {
+                    root.editColorLevel0 = value
+                    root.saveSettings()
                 }
             }
         }
@@ -132,30 +170,38 @@ ColumnLayout {
                 color: Color.mOnSurfaceVariant
             }
 
-            RowLayout {
-                spacing: Style.marginS
+            ColorSwatchRow {
+                selected: root.editColorActive
+                onPicked: value => {
+                    root.editColorActive = value
+                    root.saveSettings()
+                }
+            }
+        }
 
-                Repeater {
-                    id: activeColor
-                    model: root.noctaliaPalette
+        // Space separator
+        Item { Layout.preferredHeight: Style.marginS }
 
-                    Rectangle {
-                        width: root.swatchSize
-                        height: root.swatchSize
-                        radius: root.swatchSize / 2
-                        color: modelData
-                        border.color: (root.editColorActive && Qt.colorEqual(root.editColorActive, modelData)) ? Color.mOnSurface : Color.mOutline
-                        border.width: (root.editColorActive && Qt.colorEqual(root.editColorActive, modelData)) ? root.swatchBorderSelected : root.swatchBorderDefault
+        // Automatic mode color (optional, neutral by default)
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: Style.marginS
 
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                root.editColorActive = modelData
-                                root.saveSettings()
-                            }
-                        }
-                    }
+            NText {
+                text: pluginApi?.tr("settings.color-auto")
+                font.weight: Font.Bold
+            }
+            NText {
+                text: pluginApi?.tr("settings.color-auto-desc")
+                font.pointSize: Style.fontSizeS
+                color: Color.mOnSurfaceVariant
+            }
+
+            ColorSwatchRow {
+                selected: root.editColorAuto
+                onPicked: value => {
+                    root.editColorAuto = value
+                    root.saveSettings()
                 }
             }
         }

--- a/thinkpad-fan/SettingsView.qml
+++ b/thinkpad-fan/SettingsView.qml
@@ -20,21 +20,38 @@ ColumnLayout {
         pluginApi?.manifest?.metadata?.defaultSettings?.allowPopupOpening ??
         true
 
+    property string editColorLevel0:
+        pluginApi?.pluginSettings?.colorLevel0 ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorLevel0 ??
+        Color.mError
+
+    property string editColorActive:
+        pluginApi?.pluginSettings?.colorActive ??
+        pluginApi?.manifest?.metadata?.defaultSettings?.colorActive ??
+        Color.mPrimary
+
     // ===== SAVE =====
     function saveSettings() {
         if (!pluginApi) return
         pluginApi.pluginSettings.colorizeByStatus = root.editColorizeByStatus
         pluginApi.pluginSettings.allowPopupOpening = root.editAllowPopupOpening
+        pluginApi.pluginSettings.colorActive = root.editColorActive
+        pluginApi.pluginSettings.colorLevel0 = root.editColorLevel0
         pluginApi.saveSettings()
     }
 
     // ===== UI =====
-    NText {
-        text: pluginApi?.tr("settings.title")
-        pointSize: Style.fontSizeM
-        font.weight: Font.Bold
-        color: Color.mOnSurface
-    }
+
+    // Color swatch sizing
+    readonly property int swatchSize: 28
+    readonly property int swatchBorderSelected: 3
+    readonly property int swatchBorderDefault: 1
+
+    // All palette colors
+    readonly property var noctaliaPalette: [
+        Color.mPrimary, Color.mSecondary, Color.mTertiary, Color.mError,
+        Color.mSurface, Color.mSurfaceVariant, Color.mOutline
+    ]
 
     // Option 1: Dynamic coloring based on fan status
     NToggle {
@@ -45,6 +62,102 @@ ColumnLayout {
         onToggled: checked => {
             root.editColorizeByStatus = checked
             root.saveSettings()
+        }
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Style.marginM
+        enabled: root.editColorizeByStatus
+        opacity: enabled ? 1.0 : 0.5
+
+        // Level 0 color
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: Style.marginS
+
+            NText {
+                text: pluginApi?.tr("settings.color-level0")
+                font.weight: Font.Bold
+            }
+            NText {
+                text: pluginApi?.tr("settings.color-level0-desc")
+                font.pointSize: Style.fontSizeS
+                color: Color.mOnSurfaceVariant
+            }
+
+            RowLayout {
+                spacing: Style.marginS
+
+                Repeater {
+                    id: level0Color
+                    model: root.noctaliaPalette
+
+                    Rectangle {
+                        width: root.swatchSize
+                        height: root.swatchSize
+                        radius: root.swatchSize / 2
+                        color: modelData
+                        border.color: (root.editColorLevel0 && Qt.colorEqual(root.editColorLevel0, modelData)) ? Color.mOnSurface : Color.mOutline
+                        border.width: (root.editColorLevel0 && Qt.colorEqual(root.editColorLevel0, modelData)) ? root.swatchBorderSelected : root.swatchBorderDefault
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.editColorLevel0 = modelData
+                                root.saveSettings()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Space separator
+        Item { Layout.preferredHeight: Style.marginS }
+
+        // Active (forced speed) color
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: Style.marginS
+
+            NText {
+                text: pluginApi?.tr("settings.color-active")
+                font.weight: Font.Bold
+            }
+            NText {
+                text: pluginApi?.tr("settings.color-active-desc")
+                font.pointSize: Style.fontSizeS
+                color: Color.mOnSurfaceVariant
+            }
+
+            RowLayout {
+                spacing: Style.marginS
+
+                Repeater {
+                    id: activeColor
+                    model: root.noctaliaPalette
+
+                    Rectangle {
+                        width: root.swatchSize
+                        height: root.swatchSize
+                        radius: root.swatchSize / 2
+                        color: modelData
+                        border.color: (root.editColorActive && Qt.colorEqual(root.editColorActive, modelData)) ? Color.mOnSurface : Color.mOutline
+                        border.width: (root.editColorActive && Qt.colorEqual(root.editColorActive, modelData)) ? root.swatchBorderSelected : root.swatchBorderDefault
+
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                root.editColorActive = modelData
+                                root.saveSettings()
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/thinkpad-fan/i18n/en.json
+++ b/thinkpad-fan/i18n/en.json
@@ -4,7 +4,11 @@
     "dynamic-coloring": "Dynamic coloring",
     "dynamic-coloring-desc": "Changes the color of the bar capsule when the fan is stopped or at a custom level",
     "allow-popup": "Fan speed manual override",
-    "allow-popup-desc": "Left-click on the widget to open the manual fan override panel"
+    "allow-popup-desc": "Left-click on the widget to open the manual fan override panel",
+    "color-level0": "Fan off (Level 0)",
+    "color-level0-desc": "Capsule color when the fan is off (Level 0)",
+    "color-active": "Fan active",
+    "color-active-desc": "Capsule color when the fan runs at a forced speed (every mode except automatic and off)"
   },
   "popup": {
     "title": "Fan speed manual override",
@@ -18,5 +22,8 @@
     "level-5": "5",
     "level-6": "6",
     "level-7": "7"
+  },
+  "menu": {
+    "widget-settings": "Widget Settings"
   }
 }

--- a/thinkpad-fan/i18n/en.json
+++ b/thinkpad-fan/i18n/en.json
@@ -8,7 +8,9 @@
     "color-level0": "Fan off (Level 0)",
     "color-level0-desc": "Capsule color when the fan is off (Level 0)",
     "color-active": "Fan active",
-    "color-active-desc": "Capsule color when the fan runs at a forced speed (every mode except automatic and off)"
+    "color-active-desc": "Capsule color when the fan runs at a forced speed (every mode except automatic and off)",
+    "color-auto": "Automatic mode",
+    "color-auto-desc": "Optional capsule color for automatic mode (leave on the neutral option to match the bar)"
   },
   "popup": {
     "title": "Fan speed manual override",

--- a/thinkpad-fan/i18n/it.json
+++ b/thinkpad-fan/i18n/it.json
@@ -3,8 +3,12 @@
     "title": "ThinkPad - Impostazioni ventola e controllo termico",
     "dynamic-coloring": "Colorazione dinamica",
     "dynamic-coloring-desc": "Cambia il colore della capsula nella barra quando la ventola è ferma o a un livello personalizzato",
-    "allow-popup": "Forzatura manuale della velocità",
-    "allow-popup-desc": "Fai clic con il tasto sinistro sul widget per aprire il pannello di controllo manuale della ventola"
+    "allow-popup": "Forzatura manuale della velocità della ventola",
+    "allow-popup-desc": "Fai clic con il tasto sinistro sul widget per aprire il pannello di controllo manuale della ventola",
+    "color-level0": "Ventola spenta (Livello 0)",
+    "color-level0-desc": "Colore della capsula quando la ventola è spenta (Livello 0)",
+    "color-active": "Ventola attiva",
+    "color-active-desc": "Colore della capsula quando la ventola gira a una velocità forzata (tutte le modalità tranne automatica e spenta)"
   },
   "popup": {
     "title": "Controllo manuale della ventola",
@@ -18,5 +22,8 @@
     "level-5": "5",
     "level-6": "6",
     "level-7": "7"
+  },
+  "menu": {
+    "widget-settings": "Impostazioni widget"
   }
 }

--- a/thinkpad-fan/i18n/it.json
+++ b/thinkpad-fan/i18n/it.json
@@ -8,7 +8,9 @@
     "color-level0": "Ventola spenta (Livello 0)",
     "color-level0-desc": "Colore della capsula quando la ventola è spenta (Livello 0)",
     "color-active": "Ventola attiva",
-    "color-active-desc": "Colore della capsula quando la ventola gira a una velocità forzata (tutte le modalità tranne automatica e spenta)"
+    "color-active-desc": "Colore della capsula quando la ventola gira a una velocità forzata (tutte le modalità tranne automatica e spenta)",
+    "color-auto": "Modalità automatica",
+    "color-auto-desc": "Colore opzionale della capsula per la modalità automatica (lascia l'opzione neutra per seguire la barra)"
   },
   "popup": {
     "title": "Controllo manuale della ventola",

--- a/thinkpad-fan/manifest.json
+++ b/thinkpad-fan/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "thinkpad-fan",
     "name": "ThinkPad - Fan & Thermal Control",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "minNoctaliaVersion": "4.0.0",
     "author": "Piero-93",
     "license": "GPLv3",
@@ -15,8 +15,10 @@
     },
     "metadata": {
         "defaultSettings": {
-        "colorizeByStatus": true,
-        "allowPopupOpening": true
+            "colorizeByStatus": true,
+            "allowPopupOpening": true,
+            "colorLevel0": null,
+            "colorActive": null
         }
     }
 }

--- a/thinkpad-fan/manifest.json
+++ b/thinkpad-fan/manifest.json
@@ -18,7 +18,8 @@
             "colorizeByStatus": true,
             "allowPopupOpening": true,
             "colorLevel0": null,
-            "colorActive": null
+            "colorActive": null,
+            "colorAuto": null
         }
     }
 }


### PR DESCRIPTION
## New features

  Better dynamic visual feedback for the fan status in the bar widget by:
  - Coloring the widget capsule based on the current fan mode
  - User can choose the color for the **Fan off (Level 0)**, **Fan active** (forced speed) and **Automatic** modes
  from the theme palette
  - Each mode can also be set to a **neutral** (no-color) option to match the rest of the bar
  - The manual override panel highlights the selected level using the same colors

  ## Code quality

  - Wired the bar widget to actually read the color settings (colors were previously hardcoded)
  - Added a reusable color-picker component shared across the three color settings
  - Added/improved Italian and English translations, and localized the remaining user-facing string
  - Fixed several QML warnings in the settings view