### PR TITLE
Use PanelService launcher helpers to fix keybinding open issues

### DIFF
--- a/file-search/Main.qml
+++ b/file-search/Main.qml
@@ -14,54 +14,40 @@ Item {
 
   IpcHandler {
     target: "plugin:file-search"
-    
+
     // Toggle launcher in file search mode
     function toggle() {
       if (!pluginApi) return;
-      
+
       pluginApi.withCurrentScreen(screen => {
-        var launcherPanel = PanelService.getPanel("launcherPanel", screen);
-        if (!launcherPanel) {
-          Logger.e("FileSearch", "Could not get launcher panel");
-          return;
-        }
-        
-        var searchText = launcherPanel.searchText || "";
+        var searchText = PanelService.getLauncherSearchText(screen) || "";
         var isInFileMode = searchText.startsWith(">file");
-        
-        if (!launcherPanel.isPanelOpen) {
+
+        if (!PanelService.isLauncherOpen(screen)) {
           // Launcher closed - open with file search
           Logger.i("FileSearch", "Opening launcher in file search mode");
-          launcherPanel.open();
-          launcherPanel.setSearchText(">file ");
+          PanelService.openLauncherWithSearch(screen, ">file ");
         } else if (isInFileMode) {
           // Already in file mode - close launcher
           Logger.i("FileSearch", "Closing launcher (toggle off)");
-          launcherPanel.close();
+          PanelService.closeLauncher(screen);
         } else {
           // Launcher open but different mode - switch to file search
           Logger.i("FileSearch", "Switching to file search mode");
-          launcherPanel.setSearchText(">file ");
+          PanelService.setLauncherSearchText(screen, ">file ");
         }
       });
     }
-    
+
     // Open launcher with file search and specific query
     function search(query: string) {
       if (!pluginApi) return;
-      
+
       pluginApi.withCurrentScreen(screen => {
-        var launcherPanel = PanelService.getPanel("launcherPanel", screen);
-        if (!launcherPanel) {
-          Logger.e("FileSearch", "Could not get launcher panel");
-          return;
-        }
-        
         var searchQuery = query || "";
         Logger.i("FileSearch", "Opening launcher with search query:", searchQuery);
-        
-        launcherPanel.open();
-        launcherPanel.setSearchText(">file " + searchQuery);
+
+        PanelService.openLauncherWithSearch(screen, ">file " + searchQuery);
       });
     }
   }

--- a/file-search/README.md
+++ b/file-search/README.md
@@ -15,11 +15,11 @@ Type `>file` in the Noctalia launcher to activate file search.
 **Toggle file search:**
 
 ```bash
-noctalia-shell ipc call plugin:file-search toggle
+qs -c noctalia-shell ipc call plugin:file-search toggle
 ```
 
 **Search with pre-filled query:**
 
 ```bash
-noctalia-shell ipc call plugin:file-search search "eko"
+qs -c noctalia-shell ipc call plugin:file-search search "eko"
 ```


### PR DESCRIPTION
This PR resolves an issue where opening or toggling the file search launcher via keybindings (which trigger the plugin's IPC handlers) would open the launcher without its menu/context. 

To fix this, the handlers in `Main.qml` have been refactored to use the official helper APIs on `PanelService` instead of directly accessing and mutating properties on `launcherPanel`.