### PR TITLE
ScreenShot & Record: Fixed crashes and added window selection support on Niri

### DIFF
--- a/screen-shot-and-record/BarWidget.qml
+++ b/screen-shot-and-record/BarWidget.qml
@@ -23,15 +23,6 @@ NIconButton {
   readonly property string screenName: screen?.name ?? ""
   readonly property real capsuleHeight: Style.getCapsuleHeightForScreen(screenName)
 
-  Component.onCompleted: {
-  }
-
-  Component.onDestruction: {
-  }
-
-  onRecordingChanged: {
-  }
-
   // NIconButton configuration
   baseSize: capsuleHeight
   applyUiScale: false

--- a/screen-shot-and-record/BarWidget.qml
+++ b/screen-shot-and-record/BarWidget.qml
@@ -23,6 +23,15 @@ NIconButton {
   readonly property string screenName: screen?.name ?? ""
   readonly property real capsuleHeight: Style.getCapsuleHeightForScreen(screenName)
 
+  Component.onCompleted: {
+  }
+
+  Component.onDestruction: {
+  }
+
+  onRecordingChanged: {
+  }
+
   // NIconButton configuration
   baseSize: capsuleHeight
   applyUiScale: false
@@ -40,6 +49,8 @@ NIconButton {
   onClicked: {
     if (pluginApi) {
       pluginApi.openPanel(root.screen, root)
+    } else {
+      Logger.w("ScreenShot", "[BarWidget] onClicked: no pluginApi!")
     }
   }
 

--- a/screen-shot-and-record/Main.qml
+++ b/screen-shot-and-record/Main.qml
@@ -14,6 +14,18 @@ Item {
     property string target: ""
     property string recordingCheckTarget: ""
 
+    Component.onCompleted: {
+        Logger.d("ScreenShot", "[Main] Component.onCompleted compositor=sway:",
+                 CompositorService.isSway, "hyprland:", CompositorService.isHyprland,
+                 "niri:", CompositorService.isNiri,
+                 "selectorSource=", root.selectorSource,
+                 "screens count=", Quickshell.screens?.length)
+    }
+
+    Component.onDestruction: {
+        Logger.d("ScreenShot", "[Main] Component.onDestruction")
+    }
+
     Process {
         id: recordingCheckProc
         command: ["pidof", "wf-recorder"]
@@ -22,21 +34,30 @@ Item {
             const requestedTarget = root.recordingCheckTarget
             root.recordingCheckTarget = ""
 
+            Logger.d("ScreenShot", "[Main] recordingCheckProc onExited code=", exitCode,
+                     "requestedTarget=", requestedTarget)
+
             if (requestedTarget === "") {
                 return
             }
 
             if (exitCode === 0) {
+                Logger.d("ScreenShot", "[Main] recordingCheckProc: wf-recorder is running, stopping")
                 root.stopRecording()
                 return
             }
 
+            Logger.d("ScreenShot", "[Main] recordingCheckProc: wf-recorder not running, opening selector for", requestedTarget)
             root.openSelector(requestedTarget)
         }
     }
 
     function stopRecording() {
+        Logger.d("ScreenShot", "[Main] stopRecording() pluginDir=", pluginApi?.pluginDir,
+                 "recordingActive=", root.recordingActive)
+
         if (!pluginApi?.pluginDir) {
+            Logger.w("ScreenShot", "[Main] stopRecording: no pluginDir")
             return
         }
 
@@ -50,7 +71,14 @@ Item {
             stopArgs.push("--notify")
         }
         stopArgs.push(...buildRecordingNotifyArgs())
+        Logger.d("ScreenShot", "[Main] stopRecording: executing", stopArgs)
         Quickshell.execDetached(stopArgs)
+    }
+
+    onActiveChanged: {
+    }
+
+    onRecordingActiveChanged: {
     }
 
     function buildRecordingNotifyArgs() {
@@ -65,29 +93,10 @@ Item {
         ]
     }
 
-    function openSelector(target) {
-        if (active) {
-            return
-        }
-
-        if (CompositorService.isNiri) {
-           // Show a notification that Niri is not supported (i18n only)
-            pluginApi?.mainInstance?.showToast?.(pluginApi?.tr("notify.screenshot.niriNotSupported"));
-           Logger.w("ScreenShot", "Niri is not supported for screenshots.");
-           return;
-        }
-
-        root.target = target
-        active = true
-    }
-
-    // 存储当前所有屏幕
-    property var screens: Quickshell.screens
     readonly property string selectorSource: CompositorService.isSway ? "ScreenShotSway.qml"
                                            : CompositorService.isHyprland ? "ScreenShotHypr.qml"
+                                           : CompositorService.isNiri ? "ScreenShotNiri.qml"
                                            : "ScreenShot.qml"
-
-    // 使用 Instantiator 管理选择框
     Instantiator {
         id: selectorInstantiator
         active: root.active
@@ -98,17 +107,24 @@ Item {
             onLoaded: {
                 item.pluginApi = root.pluginApi
                 item.screen = Quickshell.screens[index]
-                Logger.d("ScreenShot", (root.target))
                 item.target = root.target
                 item.closed.connect(() => root.close())
                 item.startCapture()
             }
         }
-        onObjectAdded: (index, object) => Logger.d("ScreenShot", ("Selector added for screen", index))
-        onObjectRemoved: (index, object) => Logger.d("ScreenShot", ("Selector removed for screen", index))
+    }
+
+    function openSelector(target) {
+        if (root.active) return
+
+        root.target = target
+        active = true
     }
 
     function open(target) {
+        Logger.d("ScreenShot", "[Main] open(" + target + ") recordingCheckTarget=",
+                 root.recordingCheckTarget, "active=", root.active)
+
         if (target === "record" || target === "recordsound") {
             if (root.recordingCheckTarget !== "") {
                 return
@@ -123,6 +139,8 @@ Item {
     }
 
     function close() {
+        if (!root.active) return
+
         active = false
         root.target = ""
     }

--- a/screen-shot-and-record/Main.qml
+++ b/screen-shot-and-record/Main.qml
@@ -75,12 +75,6 @@ Item {
         Quickshell.execDetached(stopArgs)
     }
 
-    onActiveChanged: {
-    }
-
-    onRecordingActiveChanged: {
-    }
-
     function buildRecordingNotifyArgs() {
         return [
             "--notify-app", pluginApi?.tr("notify.app.recorder"),

--- a/screen-shot-and-record/Panel.qml
+++ b/screen-shot-and-record/Panel.qml
@@ -27,20 +27,10 @@ Item {
 
   property string target: ""
 
-  Component.onCompleted: {
-
-  }
-
   Component.onDestruction: {
     if (target != ""){
       mainInstance?.open(target)
     }
-  }
-
-  onRecordingChanged: {
-  }
-
-  onTargetChanged: {
   }
 
     Process {

--- a/screen-shot-and-record/Panel.qml
+++ b/screen-shot-and-record/Panel.qml
@@ -27,10 +27,20 @@ Item {
 
   property string target: ""
 
+  Component.onCompleted: {
+
+  }
+
   Component.onDestruction: {
     if (target != ""){
       mainInstance?.open(target)
     }
+  }
+
+  onRecordingChanged: {
+  }
+
+  onTargetChanged: {
   }
 
     Process {

--- a/screen-shot-and-record/README.md
+++ b/screen-shot-and-record/README.md
@@ -1,7 +1,8 @@
 # Screenshot Plugin
 
-**This plugin currently supports Sway. Hyprland and MangoWM. Window selection is only avaible in Sway and Hyrland. MangoWM/MangoWC only supports region selection.  
-> **Note:** Niri is currently not supported.
+**This plugin currently supports Sway, Hyprland, MangoWM and Niri. Window selection is available in Sway, Hyprland and Niri. MangoWM/MangoWC only supports region selection.  
+
+> **Niri Prerequisites and Limitations:** Window detection requires Niri with [PR #3305](https://github.com/YaLTeR/niri/pull/3305) (not yet merged). Due to f64 rounding in the PR, window borders may have up to 1px of offset. Niri builds without `window-geometries` (from #3305) will silently disable window detection — screenshot capture still works normally.
 
 This plugin implements screen region selection, window selection, text recognition, Google Lens, and screen recording functionality based on Quickshell.
 

--- a/screen-shot-and-record/ScreenShot.qml
+++ b/screen-shot-and-record/ScreenShot.qml
@@ -35,16 +35,9 @@ PanelWindow {
     property string frozenSourceFile: ""
     property bool frozenSourceReady: false
 
-    Component.onCompleted: {
-    }
-
     Component.onDestruction: {
         freezeCaptureProc.running = false
         checkRecordingProc.running = false
-    }
-
-
-    onDraggingChanged: {
     }
 
     Process {
@@ -135,11 +128,6 @@ PanelWindow {
     property var targetMeta: root
     property var onNonRecordingStart: null
     property var resolveFallbackRegion: null
-
-    onRegionWidthChanged: {
-        if (root.dragging) {
-        }
-    }
 
     ScreenShotCaptureCommon {
         id: captureCommon

--- a/screen-shot-and-record/ScreenShot.qml
+++ b/screen-shot-and-record/ScreenShot.qml
@@ -28,13 +28,24 @@ PanelWindow {
                                ?? pluginApi?.manifest?.metadata?.defaultSettings?.enableCross
                                ?? true
 
-    // Track if mouse is currently on this screen
     property bool mouseOnThisScreen: false
 
     readonly property real monitorOffsetX: Number(root.screen?.x ?? 0)
     readonly property real monitorOffsetY: Number(root.screen?.y ?? 0)
     property string frozenSourceFile: ""
     property bool frozenSourceReady: false
+
+    Component.onCompleted: {
+    }
+
+    Component.onDestruction: {
+        freezeCaptureProc.running = false
+        checkRecordingProc.running = false
+    }
+
+
+    onDraggingChanged: {
+    }
 
     Process {
         id: checkRecordingProc
@@ -43,7 +54,6 @@ PanelWindow {
         onExited: (exitCode) => {
             if (exitCode === 0) {
                 if (root.target === "record" || root.target === "recordsound"){
-                    // Stop flow: if recorder is already running, stop it immediately.
                     if (pluginApi?.mainInstance) {
                         pluginApi.mainInstance.recordingActive = false
                     }
@@ -59,6 +69,12 @@ PanelWindow {
                     Quickshell.execDetached(stopArgs)
                     root.closeSelector()
                 }
+            } else if (root.target === "record" || root.target === "recordsound") {
+                const outputName = root.screen ? root.screen.name : "unknown"
+                const safeOutputName = outputName.replace(/[^a-zA-Z0-9_-]/g, "_")
+                root.frozenSourceFile = `/tmp/screen-${safeOutputName}-frozen.ppm`
+                freezeCaptureProc.command = ["grim", "-t", "ppm", "-o", outputName, root.frozenSourceFile]
+                freezeCaptureProc.running = true
             }
         }
     }
@@ -68,6 +84,8 @@ PanelWindow {
         running: false
         onExited: (exitCode) => {
             root.frozenSourceReady = (exitCode === 0)
+            Logger.d("ScreenShot", "[RegionSelector] freezeCaptureProc exited with code", exitCode,
+                     "frozenSourceFile=", root.frozenSourceFile)
             if (!root.frozenSourceReady) {
                 Logger.w("ScreenShot", "[RegionSelector] Frozen source capture failed; falling back to live region capture")
             }
@@ -75,6 +93,16 @@ PanelWindow {
     }
 
     function startCapture() {
+        root.frozenSourceReady = false
+        root.mouseX = 0
+        root.mouseY = 0
+        root.mouseInside = false
+        root.dragging = false
+
+        const outputName = root.screen ? root.screen.name : "unknown"
+        const safeOutputName = outputName.replace(/[^a-zA-Z0-9_-]/g, "_")
+        root.frozenSourceFile = `/tmp/screen-${safeOutputName}-frozen.ppm`
+
         const isRecordingTarget = (root.target === "record" || root.target === "recordsound")
         if (isRecordingTarget) {
             checkRecordingProc.running = true
@@ -82,14 +110,8 @@ PanelWindow {
             root.onNonRecordingStart()
         }
 
-        if (root.target === "screenshot" || root.target === "search" || root.target === "ocr") {
-            const outputName = root.screen ? root.screen.name : "unknown"
-            const safeOutputName = outputName.replace(/[^a-zA-Z0-9_-]/g, "_")
-            root.frozenSourceFile = `/tmp/screen-${safeOutputName}-${Date.now()}-frozen.png`
-            root.frozenSourceReady = false
-            // Capture only the current output at scale 1 so crop coordinates stay
-            // in output-local logical pixels, which is correct for all resolutions.
-            freezeCaptureProc.command = ["sh", "-c", "command -v grim >/dev/null 2>&1 && grim -s 1 -o \"$2\" \"$1\" && test -s \"$1\"", "sh", root.frozenSourceFile, outputName]
+        if (!isRecordingTarget) {
+            freezeCaptureProc.command = ["grim", "-t", "ppm", "-o", outputName, root.frozenSourceFile]
             freezeCaptureProc.running = true
         }
     }
@@ -114,6 +136,11 @@ PanelWindow {
     property var onNonRecordingStart: null
     property var resolveFallbackRegion: null
 
+    onRegionWidthChanged: {
+        if (root.dragging) {
+        }
+    }
+
     ScreenShotCaptureCommon {
         id: captureCommon
     }
@@ -123,7 +150,6 @@ PanelWindow {
             return
         }
 
-        // Avoid destroying the selector while Qt is still dispatching pointer/hover events.
         Qt.callLater(() => {
             if (!root.visible) {
                 return
@@ -135,14 +161,24 @@ PanelWindow {
 
     function finish() {
         const mode = (root.mouseButton === Qt.RightButton) ? "edit" : "copy"
-
+        Logger.d("ScreenShot", "[RegionSelector] finish() mode=", mode,
+                 "regionWidth=", root.regionWidth, "regionHeight=", root.regionHeight,
+                 "dragStartX=", root.dragStartX, "dragStartY=", root.dragStartY,
+                 "draggingX=", root.draggingX, "draggingY=", root.draggingY,
+                 "frozenSourceReady=", root.frozenSourceReady,
+                 "frozenSourceFile=", root.frozenSourceFile)
         if (root.regionWidth > 0 && root.regionHeight > 0) {
             captureCommon.processRegion(root, root.regionX, root.regionY, root.regionWidth, root.regionHeight, mode)
         } else if (typeof root.resolveFallbackRegion === "function") {
             const fallback = root.resolveFallbackRegion()
             if (fallback && fallback.width > 0 && fallback.height > 0) {
                 captureCommon.processRegion(root, fallback.x, fallback.y, fallback.width, fallback.height, mode)
+            } else {
+                Logger.w("ScreenShot", "[RegionSelector] finish: fallback region invalid or empty",
+                         fallback ? JSON.stringify(fallback) : "null")
             }
+        } else {
+            Logger.w("ScreenShot", "[RegionSelector] finish: no region and no resolveFallbackRegion, nothing to capture")
         }
 
         root.closeSelector()

--- a/screen-shot-and-record/ScreenShotCaptureCommon.qml
+++ b/screen-shot-and-record/ScreenShotCaptureCommon.qml
@@ -5,32 +5,6 @@ import qs.Commons
 QtObject {
     id: common
 
-    function shellQuote(value) {
-        return "'" + String(value ?? "").replace(/'/g, "'\"'\"'") + "'"
-    }
-
-    function buildShellRequireCmdFn(appName, failedTitle, missingMessage) {
-        return `require_cmd() { if ! command -v "$1" >/dev/null 2>&1; then notify-send -a ${shellQuote(appName)} ${shellQuote(failedTitle)} ${shellQuote(missingMessage)}; exit 1; fi; }`
-    }
-
-    function buildFrozenCropCmd(sourceFile, cropGeometry, fallbackGeometry, outputPath, streamOutput) {
-        const sourceArg = shellQuote(sourceFile)
-        const cropArg = shellQuote(cropGeometry)
-        const fallbackArg = shellQuote(fallbackGeometry)
-        const magickOut = streamOutput ? "png:-" : shellQuote(outputPath)
-        const grimOut = streamOutput ? "-" : shellQuote(outputPath)
-
-        return `if command -v magick >/dev/null 2>&1; then magick ${sourceArg} -crop ${cropArg} +repage ${magickOut}; elif command -v convert >/dev/null 2>&1; then convert ${sourceArg} -crop ${cropArg} +repage ${magickOut}; else grim -g ${fallbackArg} ${grimOut}; fi`
-    }
-
-    function buildEditorCmd(editor, inputFile, outputFile) {
-        if (editor === "satty") {
-            return `satty --filename ${shellQuote(inputFile)} --output-filename ${shellQuote(outputFile)}`
-        }
-
-        return `${editor} -f ${shellQuote(inputFile)} -o ${shellQuote(outputFile)}`
-    }
-
     function buildRecordingNotifyArgs(pluginApi) {
         return [
             "--notify-app", pluginApi?.tr("notify.app.recorder"),
@@ -55,15 +29,20 @@ QtObject {
             }
         }
 
-        const scale = Number(matched?.scale ?? 1)
+        const rawScale = matched?.scale
+        const scale = (rawScale !== null && rawScale !== undefined) ? Number(rawScale) : NaN
         const dpr = Number(matched?.devicePixelRatio ?? 1)
-        return (Number.isFinite(scale) && scale > 1.01) || (Number.isFinite(dpr) && dpr > 1.01)
+        const result = (Number.isFinite(scale) && scale > 1.01) || (Number.isFinite(dpr) && dpr > 1.01)
+        return result
     }
 
     function processRegion(host, x, y, width, height, mode) {
         const pluginApi = host.pluginApi
 
-        const scale = Number(host.screen?.scale ?? 1)
+        if (!pluginApi) return
+
+        const rawScale = host.screen?.scale
+        const scale = (rawScale !== null && rawScale !== undefined) ? Number(rawScale) : NaN
         const dpr = Number(host.screen?.devicePixelRatio ?? 1)
         const factor = (Number.isFinite(scale) && scale > 0.01) ? scale : ((Number.isFinite(dpr) && dpr > 0.01) ? dpr : 1)
 
@@ -102,59 +81,80 @@ QtObject {
         const useFrozenSource = host.frozenSourceReady && host.frozenSourceFile !== ""
         const frozenSourceFile = host.frozenSourceFile
 
-        Logger.d("ScreenShot", host.target)
+        const scriptPath = pluginApi.pluginDir + "/capture.sh"
+
+        const notificationsEnabled = pluginApi?.pluginSettings?.notificationsEnabled
+                                    ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
+                                    ?? true
+
         if (host.target === "screenshot") {
-            const notifyApp = pluginApi?.tr("notify.app.screenshot")
-            const copiedTitle = pluginApi?.tr("notify.screenshot.copiedTitle")
-            const copiedBody = pluginApi?.tr("notify.screenshot.copiedBody")
-            const savedTitle = pluginApi?.tr("notify.screenshot.savedTitle")
+            const args = ["bash", scriptPath, "--action", "screenshot", "--geometry", geometry, "--crop-geometry", cropGeometry]
+
+            if (useFrozenSource) {
+                args.push("--frozen-source", frozenSourceFile)
+            }
+
+            if (!notificationsEnabled) {
+                args.push("--no-notify")
+            }
 
             if (mode === "copy") {
-                const copyCmd = useFrozenSource
-                    ? `${buildFrozenCropCmd(frozenSourceFile, cropGeometry, geometry, "", true)} | wl-copy --type image/png && rm -f '${frozenSourceFile}' && notify-send -a ${shellQuote(notifyApp)} ${shellQuote(copiedTitle)} ${shellQuote(copiedBody)}`
-                    : `grim -g '${geometry}' - | wl-copy --type image/png && notify-send -a ${shellQuote(notifyApp)} ${shellQuote(copiedTitle)} ${shellQuote(copiedBody)}`
-                Logger.d("ScreenShot", "[Panel] Executing copy command:", copyCmd)
-                Quickshell.execDetached(["sh", "-c", copyCmd])
+                args.push("--mode", "copy",
+                    "--copied-title", pluginApi?.tr("notify.screenshot.copiedTitle"),
+                    "--copied-body", pluginApi?.tr("notify.screenshot.copiedBody"))
             } else if (mode === "edit") {
                 const editor = pluginApi?.pluginSettings?.screenshotEditor
                                ?? pluginApi?.manifest?.metadata?.defaultSettings?.screenshotEditor
                                ?? "swappy"
-
                 const keepSourceScreenshot = pluginApi?.pluginSettings?.keepSourceScreenshot
-                                           ?? pluginApi?.manifest?.metadata?.defaultSettings?.keepSourceScreenshot
-                                           ?? false
+                                            ?? pluginApi?.manifest?.metadata?.defaultSettings?.keepSourceScreenshot
+                                            ?? false
 
-                const editorCmd = buildEditorCmd(editor, sourceFile, outputFile)
-                const editCmd = useFrozenSource
-                    ? `mkdir -p '${screenshotDir}' && ${buildFrozenCropCmd(frozenSourceFile, cropGeometry, geometry, sourceFile, false)} && rm -f '${frozenSourceFile}' && ${editorCmd} && if [ '${keepSourceScreenshot ? "true" : "false"}' != 'true' ]; then rm -f '${sourceFile}'; fi && notify-send -a ${shellQuote(notifyApp)} ${shellQuote(savedTitle)} "${outputFile}"`
-                    : `mkdir -p '${screenshotDir}' && grim -g '${geometry}' '${sourceFile}' && ${editorCmd} && if [ '${keepSourceScreenshot ? "true" : "false"}' != 'true' ]; then rm -f '${sourceFile}'; fi && notify-send -a ${shellQuote(notifyApp)} ${shellQuote(savedTitle)} "${outputFile}"`
-                Logger.d("ScreenShot", "[Panel] Executing edit command:", editCmd)
-                Quickshell.execDetached(["sh", "-c", editCmd])
+                args.push("--mode", "edit", "--editor", editor,
+                    "--source", sourceFile, "--output", outputFile,
+                    "--saved-title", pluginApi?.tr("notify.screenshot.savedTitle"))
+
+                if (keepSourceScreenshot) {
+                    args.push("--keep-source")
+                }
             }
+
+            args.push("--notify-app", pluginApi?.tr("notify.app.screenshot"))
+            Quickshell.execDetached(args)
+
         } else if (host.target === "search") {
-            const searchCmd = useFrozenSource
-                ? `${buildFrozenCropCmd(frozenSourceFile, cropGeometry, geometry, tempFile, false)} && rm -f '${frozenSourceFile}' && xdg-open \"https://lens.google.com/uploadbyurl?url=$(curl -sF files[]=@'${tempFile}' https://uguu.se/upload | jq -r '.files[0].url')\"`
-                : `grim -g '${geometry}' '${tempFile}' && xdg-open \"https://lens.google.com/uploadbyurl?url=$(curl -sF files[]=@'${tempFile}' https://uguu.se/upload | jq -r '.files[0].url')\"`
-            Logger.d("ScreenShot", "[Panel] Executing search command:", searchCmd)
-            Quickshell.execDetached(["sh", "-c", searchCmd])
+            const args = ["bash", scriptPath, "--action", "search", "--geometry", geometry, "--crop-geometry", cropGeometry]
+
+            if (useFrozenSource) {
+                args.push("--frozen-source", frozenSourceFile)
+            }
+
+            Quickshell.execDetached(args)
+
         } else if (host.target === "ocr") {
-            const notifyApp = pluginApi?.tr("notify.app.screenshot")
-            const depMissing = pluginApi?.tr("notify.dependencyMissing")
-            const failedTitle = pluginApi?.tr("notify.ocr.failed")
-            const doneTitle = pluginApi?.tr("notify.ocr.doneTitle")
-            const doneCopied = pluginApi?.tr("notify.ocr.copiedBody")
-            const doneNoText = pluginApi?.tr("notify.ocr.emptyBody")
-            const ocrPreamble = buildShellRequireCmdFn(notifyApp, failedTitle, depMissing)
-            const ocrCmd = useFrozenSource
-                ? `${ocrPreamble}; require_cmd grim; require_cmd tesseract; require_cmd wl-copy; OCR_TEXT=""; ${buildFrozenCropCmd(frozenSourceFile, cropGeometry, geometry, tempFile, false)} && rm -f '${frozenSourceFile}'; if [ -s '${tempFile}' ]; then OCR_TEXT=$(tesseract '${tempFile}' stdout 2>/dev/null); fi; if [ -n "$OCR_TEXT" ]; then printf "%s" "$OCR_TEXT" | wl-copy; notify-send -a ${shellQuote(notifyApp)} ${shellQuote(doneTitle)} ${shellQuote(doneCopied)}; else notify-send -a ${shellQuote(notifyApp)} ${shellQuote(doneTitle)} ${shellQuote(doneNoText)}; fi`
-                : `${ocrPreamble}; require_cmd grim; require_cmd tesseract; require_cmd wl-copy; OCR_TEXT=""; if grim -g '${geometry}' '${tempFile}'; then OCR_TEXT=$(tesseract '${tempFile}' stdout 2>/dev/null); fi; if [ -n "$OCR_TEXT" ]; then printf "%s" "$OCR_TEXT" | wl-copy; notify-send -a ${shellQuote(notifyApp)} ${shellQuote(doneTitle)} ${shellQuote(doneCopied)}; else notify-send -a ${shellQuote(notifyApp)} ${shellQuote(doneTitle)} ${shellQuote(doneNoText)}; fi`
-            Logger.d("ScreenShot", "[Panel] Executing ocr command:", ocrCmd)
-            Quickshell.execDetached(["sh", "-c", ocrCmd])
+            const args = ["bash", scriptPath, "--action", "ocr", "--geometry", geometry, "--crop-geometry", cropGeometry]
+
+            if (useFrozenSource) {
+                args.push("--frozen-source", frozenSourceFile)
+            }
+
+            if (!notificationsEnabled) {
+                args.push("--no-notify")
+            }
+
+            args.push("--notify-app", pluginApi?.tr("notify.app.screenshot"),
+                "--ocr-done-title", pluginApi?.tr("notify.ocr.doneTitle"),
+                "--ocr-copied-body", pluginApi?.tr("notify.ocr.copiedBody"),
+                "--ocr-empty-body", pluginApi?.tr("notify.ocr.emptyBody"),
+                "--dep-missing", pluginApi?.tr("notify.dependencyMissing"),
+                "--ocr-failed", pluginApi?.tr("notify.ocr.failed"))
+
+            Quickshell.execDetached(args)
+
         } else if (host.target === "record" || host.target === "recordsound") {
-            const scriptPath = pluginApi.pluginDir + "/record.sh"
             var configuredRecordingSavePath = pluginApi?.pluginSettings?.recordingSavePath
-                                            ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingSavePath
-                                            ?? ""
+                                             ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingSavePath
+                                             ?? ""
             var recordingDir = Settings.preprocessPath(configuredRecordingSavePath)
             if (!recordingDir || recordingDir === "") {
                 recordingDir = Quickshell.env("HOME") + "/Videos"
@@ -166,7 +166,7 @@ QtObject {
 
             const region = `${globalX},${globalY} ${globalW}x${globalH}`
 
-            const recordArgs = ["bash", scriptPath, "--region", region, "--dir", recordingDir]
+            const recordArgs = ["bash", pluginApi.pluginDir + "/record.sh", "--region", region, "--dir", recordingDir]
             if (shouldNormalizeRecordingResolution(host)) {
                 const targetSize = `${globalW}x${globalH}`
                 recordArgs.push("--video-target-size", targetSize)
@@ -174,12 +174,11 @@ QtObject {
             if (host.target === "recordsound") {
                 recordArgs.push("--sound")
             }
-            if (recordingNotificationsEnabled) {
+            if (recordingNotificationsEnabled && notificationsEnabled) {
                 recordArgs.push("--notify")
             }
             recordArgs.push(...buildRecordingNotifyArgs(pluginApi))
 
-            Logger.d("ScreenShot", "[Panel] Executing record command args:", recordArgs)
             const recordStarted = Quickshell.execDetached(recordArgs)
             if (pluginApi?.mainInstance) {
                 pluginApi.mainInstance.recordingActive = (recordStarted !== false)

--- a/screen-shot-and-record/ScreenShotCaptureCommon.qml
+++ b/screen-shot-and-record/ScreenShotCaptureCommon.qml
@@ -83,12 +83,16 @@ QtObject {
 
         const scriptPath = pluginApi.pluginDir + "/capture.sh"
 
+        const pngCompressionLevel = pluginApi?.pluginSettings?.pngCompressionLevel
+                                    ?? pluginApi?.manifest?.metadata?.defaultSettings?.pngCompressionLevel
+                                    ?? 1
+
         const notificationsEnabled = pluginApi?.pluginSettings?.notificationsEnabled
-                                    ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
-                                    ?? true
+                                     ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
+                                     ?? true
 
         if (host.target === "screenshot") {
-            const args = ["bash", scriptPath, "--action", "screenshot", "--geometry", geometry, "--crop-geometry", cropGeometry]
+            const args = ["bash", scriptPath, "--action", "screenshot", "--geometry", geometry, "--crop-geometry", cropGeometry, "--png-compression-level", String(pngCompressionLevel)]
 
             if (useFrozenSource) {
                 args.push("--frozen-source", frozenSourceFile)
@@ -123,7 +127,7 @@ QtObject {
             Quickshell.execDetached(args)
 
         } else if (host.target === "search") {
-            const args = ["bash", scriptPath, "--action", "search", "--geometry", geometry, "--crop-geometry", cropGeometry]
+            const args = ["bash", scriptPath, "--action", "search", "--geometry", geometry, "--crop-geometry", cropGeometry, "--png-compression-level", String(pngCompressionLevel)]
 
             if (useFrozenSource) {
                 args.push("--frozen-source", frozenSourceFile)
@@ -132,7 +136,7 @@ QtObject {
             Quickshell.execDetached(args)
 
         } else if (host.target === "ocr") {
-            const args = ["bash", scriptPath, "--action", "ocr", "--geometry", geometry, "--crop-geometry", cropGeometry]
+            const args = ["bash", scriptPath, "--action", "ocr", "--geometry", geometry, "--crop-geometry", cropGeometry, "--png-compression-level", String(pngCompressionLevel)]
 
             if (useFrozenSource) {
                 args.push("--frozen-source", frozenSourceFile)

--- a/screen-shot-and-record/ScreenShotHypr.qml
+++ b/screen-shot-and-record/ScreenShotHypr.qml
@@ -35,7 +35,6 @@ ScreenShot {
     }
 
     resolveFallbackRegion: () => {
-                 root.hoveredWindow ? JSON.stringify({x: root.hoveredWindow.x, y: root.hoveredWindow.y, w: root.hoveredWindow.width, h: root.hoveredWindow.height}) : "null")
         if (!root.hoveredWindow) {
             return null
         }

--- a/screen-shot-and-record/ScreenShotHypr.qml
+++ b/screen-shot-and-record/ScreenShotHypr.qml
@@ -35,6 +35,7 @@ ScreenShot {
     }
 
     resolveFallbackRegion: () => {
+                 root.hoveredWindow ? JSON.stringify({x: root.hoveredWindow.x, y: root.hoveredWindow.y, w: root.hoveredWindow.width, h: root.hoveredWindow.height}) : "null")
         if (!root.hoveredWindow) {
             return null
         }
@@ -64,14 +65,19 @@ ScreenShot {
             }
         }
         onExited: (code) => {
+            Logger.d("ScreenShot", "[Hyprland] hyprctlProc onExited code=", code)
             if (code !== 0) {
                 root.windowRegions = []
+                Logger.w("ScreenShot", "[Hyprland] hyprctlProc failed, cleared windowRegions")
             }
         }
     }
 
     function extractHyprWindowRegions(clients) {
+        const clientCount = Array.isArray(clients) ? clients.length : 0
+
         if (!Array.isArray(clients)) {
+            Logger.w("ScreenShot", "[Hyprland] extractHyprWindowRegions: clients is not an array")
             return []
         }
 
@@ -80,7 +86,7 @@ ScreenShot {
         const workspaceId = Number(root.activeWorkspaceId)
         const monitorId = Number(root.hyprlandMonitor?.id ?? NaN)
 
-        return clients
+        const filtered = clients
             .filter(client => {
                 const isMapped = client?.mapped !== false
                 const isHidden = client?.hidden === true
@@ -102,6 +108,9 @@ ScreenShot {
 
                 return isMapped && !isHidden && onOutput
             })
+
+
+        const result = filtered
             .map(client => ({
                 x: Number(client?.at?.[0] ?? 0) - root.monitorOffsetX,
                 y: Number(client?.at?.[1] ?? 0) - root.monitorOffsetY,
@@ -112,6 +121,8 @@ ScreenShot {
                 address: String(client?.address ?? "")
             }))
             .filter(window => window.width > 0 && window.height > 0)
+
+        return result
     }
 
     function findWindowAt(x, y) {

--- a/screen-shot-and-record/ScreenShotNiri.qml
+++ b/screen-shot-and-record/ScreenShotNiri.qml
@@ -1,0 +1,164 @@
+import QtQuick
+import Quickshell.Io
+import qs.Commons
+
+ScreenShot {
+    id: root
+    readonly property bool enableWindowsSelection: pluginApi?.pluginSettings?.enableWindowsSelection
+                                                   ?? pluginApi?.manifest?.metadata?.defaultSettings?.enableWindowsSelection
+                                                   ?? true
+
+    property list<var> windowRegions: []
+    property var hoveredWindow: null
+    property var winMap: ({})
+
+    onEnableWindowsSelectionChanged: {
+        if (!root.enableWindowsSelection) {
+            root.windowRegions = []
+            root.hoveredWindow = null
+        }
+    }
+
+    onNonRecordingStart: () => {
+        Logger.d("ScreenShot", "[Niri] onNonRecordingStart enableWindowsSelection=", root.enableWindowsSelection)
+        if (root.enableWindowsSelection) {
+            root.windowRegions = []
+            niriWindowsProc.running = true
+        }
+    }
+
+    onTargetChanged: {
+        if (root.enableWindowsSelection && (root.target === "record" || root.target === "recordsound")) {
+            root.windowRegions = []
+            niriWindowsProc.running = true
+        }
+    }
+
+    resolveFallbackRegion: () => {
+        if (!root.hoveredWindow) {
+            return null
+        }
+        return {
+            x: root.hoveredWindow.x,
+            y: root.hoveredWindow.y,
+            width: root.hoveredWindow.width,
+            height: root.hoveredWindow.height
+        }
+    }
+
+    Process {
+        id: niriWindowsProc
+        command: ["niri", "msg", "-j", "windows"]
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const windows = JSON.parse(text)
+                    root.winMap = {}
+                    for (const w of windows) {
+                        root.winMap[String(w.id)] = w
+                    }
+                    niriGeomProc.running = true
+                } catch (e) {
+                    root.windowRegions = []
+                    Logger.w("ScreenShot", "[Niri] windows parse error:", e)
+                }
+            }
+        }
+        onExited: (code) => {
+            if (code !== 0) {
+                root.windowRegions = []
+                Logger.w("ScreenShot", "[Niri] niriWindowsProc failed")
+            }
+        }
+    }
+
+    Process {
+        id: niriGeomProc
+        command: ["niri", "msg", "-j", "window-geometries"]
+        running: false
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const geometries = JSON.parse(text)
+                    root.windowRegions = root.computeRegions(geometries)
+                    Logger.d("ScreenShot", "[RegionSelector][Niri] Found", root.windowRegions.length, "windows on", root.screen?.name)
+                } catch (e) {
+                    root.windowRegions = []
+                    Logger.w("ScreenShot", "[Niri] geometries parse error:", e)
+                }
+            }
+        }
+        onExited: (code) => {
+            if (code !== 0) {
+                root.windowRegions = []
+            }
+        }
+    }
+
+    function computeRegions(geometries) {
+        if (!Array.isArray(geometries)) {
+            Logger.w("ScreenShot", "[Niri] computeRegions: geometries is not an array")
+            return []
+        }
+
+        const focusedEntry = Object.entries(root.winMap).find(([id, w]) => w.is_focused === true)
+        if (!focusedEntry) {
+            Logger.d("ScreenShot", "[Niri] computeRegions: no focused window")
+            return []
+        }
+        const activeWsId = Number(focusedEntry[1].workspace_id ?? 0)
+
+        const outputName = String(root.screen?.name ?? "")
+        const outputWidth = Number(root.screen?.width ?? 0)
+        const outputHeight = Number(root.screen?.height ?? 0)
+
+
+        const result = []
+        for (const g of geometries) {
+            const win = root.winMap[String(g.id)]
+            if (!win) continue
+            if (Number(win.workspace_id ?? 0) !== activeWsId) continue
+
+            const l = win.layout
+            const tileX = Number(g.x)
+            const tileY = Number(g.y)
+            const winOffX = Number(l.window_offset_in_tile[0] ?? 0)
+            const winOffY = Number(l.window_offset_in_tile[1] ?? 0)
+            const winW = Number(l.window_size[0] ?? 0)
+            const winH = Number(l.window_size[1] ?? 0)
+
+            if (winW <= 0 || winH <= 0) continue
+
+            const visX = tileX + winOffX
+            const visY = tileY + winOffY
+
+            if (visX + winW < 0 || visX > outputWidth || visY + winH < 0 || visY > outputHeight) continue
+
+            result.push({
+                x: Math.round(visX) - root.monitorOffsetX,
+                y: Math.round(visY) - root.monitorOffsetY,
+                width: Math.round(winW),
+                height: Math.round(winH),
+                title: String(win.title ?? ""),
+                cls: String(win.app_id ?? ""),
+                address: String(g.id ?? ""),
+                floating: win.is_floating === true
+            })
+        }
+
+        result.sort((a, b) => Number(a.floating) - Number(b.floating))
+
+        return result
+    }
+
+    function findWindowAt(x, y) {
+        for (let i = root.windowRegions.length - 1; i >= 0; i--) {
+            const w = root.windowRegions[i]
+            if (x >= w.x && x <= w.x + w.width && y >= w.y && y <= w.y + w.height) {
+                return w
+            }
+        }
+        return null
+    }
+}

--- a/screen-shot-and-record/ScreenShotOverlayCommon.qml
+++ b/screen-shot-and-record/ScreenShotOverlayCommon.qml
@@ -10,100 +10,106 @@ Item {
 
     anchors.fill: parent
 
-    ScreencopyView {
+    Item {
+        id: contentRoot
         anchors.fill: parent
-        live: false
-        captureSource: host?.screen
-    }
+        visible: host?.frozenSourceReady ?? false
 
-    Repeater {
-        model: host?.windowRegions ?? []
-        delegate: Rectangle {
-            required property var modelData
+        // grim-captured PNG avoids wlr-screencopy async callback racing with surface destruction
+        Image {
+            anchors.fill: parent
+            source: host?.frozenSourceReady ? "file://" + host?.frozenSourceFile : ""
+            fillMode: Image.Stretch
+        }
+
+        Repeater {
+            model: host?.windowRegions ?? []
+            delegate: Rectangle {
+                required property var modelData
+                z: 1
+                x: modelData.x
+                y: modelData.y
+                width: modelData.width
+                height: modelData.height
+                color: targeted ? "#22ffffff" : "transparent"
+                border.color: targeted ? "#aaffffff" : "#55ffffff"
+                border.width: targeted ? Math.max(2, Math.round(3 * (host?.uiScale ?? 1))) : Math.max(1, Math.round(host?.uiScale ?? 1))
+                visible: !(host?.dragging ?? false) && parent.parent.visible
+
+                readonly property bool targeted:
+                    host?.hoveredWindow !== null && host?.hoveredWindow?.address === modelData.address
+
+                Behavior on border.width { NumberAnimation { duration: 80 } }
+                Behavior on color { ColorAnimation { duration: 80 } }
+            }
+        }
+
+        Rectangle {
+            id: darkenOverlay
             z: 1
-            x: modelData.x
-            y: modelData.y
-            width: modelData.width
-            height: modelData.height
-            color: targeted ? "#22ffffff" : "transparent"
-            border.color: targeted ? "#aaffffff" : "#55ffffff"
-            border.width: targeted ? Math.max(2, Math.round(3 * (host?.uiScale ?? 1))) : Math.max(1, Math.round(host?.uiScale ?? 1))
-            visible: !(host?.dragging ?? false) && (host?.mouseOnThisScreen ?? false)
-
-            readonly property bool targeted:
-                host?.hoveredWindow !== null && host?.hoveredWindow?.address === modelData.address
-
-            Behavior on border.width { NumberAnimation { duration: 80 } }
-            Behavior on color { ColorAnimation { duration: 80 } }
+            anchors {
+                left: parent.left
+                top: parent.top
+                leftMargin: (host?.regionX ?? 0) - border.width
+                topMargin: (host?.regionY ?? 0) - border.width
+            }
+            width: (host?.regionWidth ?? 0) + border.width * 2
+            height: (host?.regionHeight ?? 0) + border.width * 2
+            color: "transparent"
+            border.color: "#88111111"
+            border.width: Math.max(parent.width, parent.height)
+            visible: (host?.dragging ?? false) && parent.parent.visible
         }
-    }
 
-    Rectangle {
-        id: darkenOverlay
-        z: 1
-        anchors {
-            left: parent.left
-            top: parent.top
-            leftMargin: (host?.regionX ?? 0) - border.width
-            topMargin: (host?.regionY ?? 0) - border.width
+        Rectangle {
+            z: 2
+            x: host?.regionX ?? 0
+            y: host?.regionY ?? 0
+            width: host?.regionWidth ?? 0
+            height: host?.regionHeight ?? 0
+            color: "transparent"
+            border.color: "#cccccc"
+            border.width: Math.max(1, Math.round(2 * (host?.uiScale ?? 1)))
+            visible: (host?.dragging ?? false) && parent.parent.visible
         }
-        width: (host?.regionWidth ?? 0) + border.width * 2
-        height: (host?.regionHeight ?? 0) + border.width * 2
-        color: "transparent"
-        border.color: "#88111111"
-        border.width: Math.max(parent.width, parent.height)
-        visible: (host?.dragging ?? false) && (host?.mouseOnThisScreen ?? false)
-    }
 
-    Rectangle {
-        z: 2
-        x: host?.regionX ?? 0
-        y: host?.regionY ?? 0
-        width: host?.regionWidth ?? 0
-        height: host?.regionHeight ?? 0
-        color: "transparent"
-        border.color: "#cccccc"
-        border.width: Math.max(1, Math.round(2 * (host?.uiScale ?? 1)))
-        visible: (host?.dragging ?? false) && (host?.mouseOnThisScreen ?? false)
-    }
+        Text {
+            z: 3
+            x: (host?.regionX ?? 0) + (host?.regionWidth ?? 0) - width - (8 * (host?.uiScale ?? 1))
+            y: (host?.regionY ?? 0) + (host?.regionHeight ?? 0) + (8 * (host?.uiScale ?? 1))
+            text: (host?.dragging ?? false) ? `${Math.round(host?.regionWidth ?? 0)} x ${Math.round(host?.regionHeight ?? 0)}` : ""
+            color: "#cccccc"
+            font.pixelSize: Math.max(10, Math.round(13 * (host?.uiScale ?? 1)))
+            visible: (host?.dragging ?? false) && parent.parent.visible
+        }
 
-    Text {
-        z: 3
-        x: (host?.regionX ?? 0) + (host?.regionWidth ?? 0) - width - (8 * (host?.uiScale ?? 1))
-        y: (host?.regionY ?? 0) + (host?.regionHeight ?? 0) + (8 * (host?.uiScale ?? 1))
-        text: (host?.dragging ?? false) ? `${Math.round(host?.regionWidth ?? 0)} x ${Math.round(host?.regionHeight ?? 0)}` : ""
-        color: "#cccccc"
-        font.pixelSize: Math.max(10, Math.round(13 * (host?.uiScale ?? 1)))
-        visible: (host?.dragging ?? false) && (host?.mouseOnThisScreen ?? false)
-    }
+        Rectangle {
+            visible: (host?.enableCross ?? false) && parent.parent.visible
+            opacity: 0.4
+            z: 2
+            x: host?.mouseX ?? 0
+            anchors { top: parent.top; bottom: parent.bottom }
+            width: Math.max(1, Math.round(host?.uiScale ?? 1))
+            color: "#cccccc"
+        }
+        Rectangle {
+            visible: (host?.enableCross ?? false) && parent.parent.visible
+            opacity: 0.4
+            z: 2
+            y: host?.mouseY ?? 0
+            anchors { left: parent.left; right: parent.right }
+            height: Math.max(1, Math.round(host?.uiScale ?? 1))
+            color: "#cccccc"
+        }
 
-    Rectangle {
-        visible: (host?.mouseInside ?? false) && (host?.enableCross ?? false) && (host?.mouseOnThisScreen ?? false)
-        opacity: 0.4
-        z: 2
-        x: host?.mouseX ?? 0
-        anchors { top: parent.top; bottom: parent.bottom }
-        width: Math.max(1, Math.round(host?.uiScale ?? 1))
-        color: "#cccccc"
-    }
-    Rectangle {
-        visible: (host?.mouseInside ?? false) && (host?.enableCross ?? false) && (host?.mouseOnThisScreen ?? false)
-        opacity: 0.4
-        z: 2
-        y: host?.mouseY ?? 0
-        anchors { left: parent.left; right: parent.right }
-        height: Math.max(1, Math.round(host?.uiScale ?? 1))
-        color: "#cccccc"
-    }
+        Rectangle {
+            anchors.fill: parent
+            color: "#88111111"
+            visible: !(host?.dragging ?? false) && parent.parent.visible
+            z: 0
+        }
 
-    Rectangle {
-        anchors.fill: parent
-        color: "#88111111"
-        visible: !(host?.dragging ?? false) && (host?.mouseOnThisScreen ?? false)
-        z: 0
-    }
-
-    MouseArea {
+        MouseArea {
         anchors.fill: parent
         hoverEnabled: true
         cursorShape: (host?.enableCross ?? false) ? Qt.CrossCursor : Qt.ArrowCursor
@@ -119,46 +125,50 @@ Item {
                 host.draggingX = mouse.x
                 host.draggingY = mouse.y
             } else if (typeof host.findWindowAt === "function") {
-                host.hoveredWindow = host.findWindowAt(mouse.x, mouse.y)
+                // Skip window detection near the bottom toolbar area (NBox + margin + buffer)
+                if (mouse.y < (parent?.height ?? 999) - 100) {
+                    host.hoveredWindow = host.findWindowAt(mouse.x, mouse.y)
+                }
             }
         }
-        onEntered: {
-            host.mouseOnThisScreen = true
-            host.mouseInside = true
-        }
-        onExited: {
-            host.mouseInside = false
+            onEntered: {
+                host.mouseOnThisScreen = true
+                host.mouseInside = true
+            }
+            onExited: {
+                host.mouseInside = false
             host.mouseOnThisScreen = false
             if (host.hoveredWindow !== undefined) {
                 host.hoveredWindow = null
             }
         }
-        onPressed: (mouse) => {
-            host.dragStartX = mouse.x
-            host.dragStartY = mouse.y
-            host.draggingX = mouse.x
-            host.draggingY = mouse.y
-            host.dragging = true
-            host.mouseButton = mouse.button
-        }
-        onReleased: (mouse) => {
-            host.dragging = false
-            host.finish()
-        }
+            onPressed: (mouse) => {
+                host.dragStartX = mouse.x
+                host.dragStartY = mouse.y
+                host.draggingX = mouse.x
+                host.draggingY = mouse.y
+                host.dragging = true
+                host.mouseButton = mouse.button
+            }
+            onReleased: (mouse) => {
+                host.dragging = false
+                host.finish()
+            }
     }
 
-    NBox {
-        id: rowBackground
-        color: Color.mPrimary
-        radius: Style.radiusM
-        width: rowLayout.implicitWidth + Style.marginL * 2
-        height: rowLayout.implicitHeight + Style.marginM * 2
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Style.marginM
-        z: 20
-        visible: host?.mouseOnThisScreen ?? false
-        opacity: (host?.mouseOnThisScreen ?? false) ? 1 : 0
+    } // end contentRoot
+
+        NBox {
+            id: rowBackground
+            color: Color.mPrimary
+            radius: Style.radiusM
+            width: rowLayout.implicitWidth + Style.marginL * 2
+            height: rowLayout.implicitHeight + Style.marginM * 2
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: Style.marginM
+            z: 20
+            visible: host?.frozenSourceReady ?? false
 
         RowLayout {
             z: 20
@@ -188,7 +198,6 @@ Item {
             }
         }
 
-        Behavior on opacity { NumberAnimation { duration: Style.animationNormal; easing.type: Easing.OutQuad } }
     }
 
     Item {

--- a/screen-shot-and-record/ScreenShotSway.qml
+++ b/screen-shot-and-record/ScreenShotSway.qml
@@ -57,8 +57,10 @@ ScreenShot {
             }
         }
         onExited: (code) => {
+            Logger.d("ScreenShot", "[Sway] swayTreeProc onExited code=", code)
             if (code !== 0) {
                 root.windowRegions = []
+                Logger.w("ScreenShot", "[Sway] swayTreeProc failed, cleared windowRegions")
             }
         }
     }
@@ -66,12 +68,16 @@ ScreenShot {
 
     function extractSwayWindowRegions(tree) {
         const outputName = String(root.screen?.name ?? "")
+
         if (outputName === "") {
+            Logger.w("ScreenShot", "[Sway] extractSwayWindowRegions: empty outputName")
             return []
         }
 
         const outputs = (tree?.nodes ?? []).filter(node => node?.type === "output" && String(node?.name ?? "") === outputName)
+
         if (outputs.length === 0) {
+            Logger.w("ScreenShot", "[Sway] extractSwayWindowRegions: no matching outputs")
             return []
         }
 
@@ -88,6 +94,7 @@ ScreenShot {
                 selectedWorkspaces = workspaces
             }
 
+
             for (let j = 0; j < selectedWorkspaces.length; j++) {
                 root.collectWorkspaceWindows(selectedWorkspaces[j], result)
             }
@@ -99,6 +106,7 @@ ScreenShot {
     function collectWorkspaceWindows(workspaceNode, result) {
         const stack = [workspaceNode]
         const seenWindowKeys = ({})
+        let processedCount = 0
         while (stack.length > 0) {
             const node = stack.pop()
             if (!node) {
@@ -125,6 +133,8 @@ ScreenShot {
             if (!isSelectableWindowNode || !hasRect) {
                 continue
             }
+
+            processedCount++
 
             const windowTitle = String(node.name ?? "")
             const windowClass = String(node.app_id ?? node.window_properties?.class ?? "")
@@ -156,8 +166,6 @@ ScreenShot {
                 return w
             }
         }
-
         return null
     }
-
 }

--- a/screen-shot-and-record/Settings.qml
+++ b/screen-shot-and-record/Settings.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import Quickshell
 import qs.Commons
 import qs.Widgets
+import qs.Services.Compositor
 
 ColumnLayout {
     id: root
@@ -35,6 +36,10 @@ ColumnLayout {
                                        ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingSavePath
                                        ?? (Quickshell.env("HOME") + "/Videos")
 
+    property bool notificationsEnabled: pluginApi?.pluginSettings?.notificationsEnabled
+                                        ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
+                                        ?? true
+
     property bool recordingNotifications: pluginApi?.pluginSettings?.recordingNotifications
                                           ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingNotifications
                                           ?? true
@@ -61,6 +66,13 @@ ColumnLayout {
         onToggled: (checked) => {
             root.enableWindowsSelection = checked
         }
+    }
+
+    NText {
+        Layout.fillWidth: true
+        text: pluginApi?.tr("settings.enableWindowsSelection.niriWarning")
+        color: "#ff4444"
+        visible: CompositorService.isNiri
     }
 
     RowLayout {
@@ -122,6 +134,16 @@ ColumnLayout {
 
     NToggle {
         Layout.fillWidth: true
+        label: pluginApi?.tr("settings.notificationsEnabled.label")
+        description: pluginApi?.tr("settings.notificationsEnabled.description")
+        checked: root.notificationsEnabled
+        onToggled: (checked) => {
+            root.notificationsEnabled = checked
+        }
+    }
+
+    NToggle {
+        Layout.fillWidth: true
         label: pluginApi?.tr("settings.recordingNotifications.label")
         description: pluginApi?.tr("settings.recordingNotifications.description")
         checked: root.recordingNotifications
@@ -162,6 +184,7 @@ ColumnLayout {
         pluginApi.pluginSettings.keepSourceScreenshot = root.keepSourceScreenshot
         pluginApi.pluginSettings.savePath = root.savePath
         pluginApi.pluginSettings.recordingSavePath = root.recordingSavePath
+        pluginApi.pluginSettings.notificationsEnabled = root.notificationsEnabled
         pluginApi.pluginSettings.recordingNotifications = root.recordingNotifications
         pluginApi.saveSettings()
     }

--- a/screen-shot-and-record/Settings.qml
+++ b/screen-shot-and-record/Settings.qml
@@ -36,9 +36,13 @@ ColumnLayout {
                                        ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingSavePath
                                        ?? (Quickshell.env("HOME") + "/Videos")
 
+    property int pngCompressionLevel: pluginApi?.pluginSettings?.pngCompressionLevel
+                                       ?? pluginApi?.manifest?.metadata?.defaultSettings?.pngCompressionLevel
+                                       ?? 1
+
     property bool notificationsEnabled: pluginApi?.pluginSettings?.notificationsEnabled
-                                        ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
-                                        ?? true
+                                         ?? pluginApi?.manifest?.metadata?.defaultSettings?.notificationsEnabled
+                                         ?? true
 
     property bool recordingNotifications: pluginApi?.pluginSettings?.recordingNotifications
                                           ?? pluginApi?.manifest?.metadata?.defaultSettings?.recordingNotifications
@@ -142,6 +146,20 @@ ColumnLayout {
         }
     }
 
+    NValueSlider {
+        Layout.fillWidth: true
+        from: 0
+        to: 9
+        stepSize: 1
+        value: root.pngCompressionLevel
+        label: pluginApi?.tr("settings.pngCompressionLevel.label")
+        description: pluginApi?.tr("settings.pngCompressionLevel.description")
+        onMoved: value => {
+            root.pngCompressionLevel = value
+        }
+        text: String(root.pngCompressionLevel)
+    }
+
     NToggle {
         Layout.fillWidth: true
         label: pluginApi?.tr("settings.recordingNotifications.label")
@@ -184,6 +202,7 @@ ColumnLayout {
         pluginApi.pluginSettings.keepSourceScreenshot = root.keepSourceScreenshot
         pluginApi.pluginSettings.savePath = root.savePath
         pluginApi.pluginSettings.recordingSavePath = root.recordingSavePath
+        pluginApi.pluginSettings.pngCompressionLevel = root.pngCompressionLevel
         pluginApi.pluginSettings.notificationsEnabled = root.notificationsEnabled
         pluginApi.pluginSettings.recordingNotifications = root.recordingNotifications
         pluginApi.saveSettings()

--- a/screen-shot-and-record/capture.sh
+++ b/screen-shot-and-record/capture.sh
@@ -20,6 +20,7 @@ OUTPUT_FILE=""
 SOURCE_FILE=""
 KEEP_SOURCE=false
 FROZEN_SOURCE=""
+PNG_COMPRESSION_LEVEL=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -42,6 +43,7 @@ while [[ $# -gt 0 ]]; do
         --ocr-empty-body) OCR_EMPTY_BODY="$2"; shift 2 ;;
         --dep-missing) DEP_MISSING="$2"; shift 2 ;;
         --ocr-failed) OCR_FAILED="$2"; shift 2 ;;
+        --png-compression-level) PNG_COMPRESSION_LEVEL="$2"; shift 2 ;;
         *) exit 1 ;;
     esac
 done
@@ -64,13 +66,18 @@ require_cmd() {
 crop_or_grim() {
     local out="$1" stream="$2"
 
+    local compress_args=()
+    if [[ -n "$PNG_COMPRESSION_LEVEL" ]]; then
+        compress_args=(-define "png:compression-level=$PNG_COMPRESSION_LEVEL")
+    fi
+
     if [[ -n "$FROZEN_SOURCE" && -f "$FROZEN_SOURCE" ]]; then
         if command -v magick &>/dev/null; then
-            if [[ "$stream" == "yes" ]]; then magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage png:-
-            else magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "$out"; fi
+            if [[ "$stream" == "yes" ]]; then magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "${compress_args[@]}" png:-
+            else magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "${compress_args[@]}" "$out"; fi
         elif command -v convert &>/dev/null; then
-            if [[ "$stream" == "yes" ]]; then convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage png:-
-            else convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "$out"; fi
+            if [[ "$stream" == "yes" ]]; then convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "${compress_args[@]}" png:-
+            else convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "${compress_args[@]}" "$out"; fi
         else
             if [[ "$stream" == "yes" ]]; then grim -g "$GEOMETRY" -
             else grim -g "$GEOMETRY" "$out"; fi

--- a/screen-shot-and-record/capture.sh
+++ b/screen-shot-and-record/capture.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+NOTIFY_FLAG=1
+NOTIFY_APP="Screenshot"
+COPIED_TITLE="Copied"
+COPIED_BODY="Image copied to clipboard"
+SAVED_TITLE="Saved"
+OCR_DONE_TITLE="OCR complete"
+OCR_COPIED_BODY="Recognized text copied to clipboard"
+OCR_EMPTY_BODY="No text detected"
+DEP_MISSING="A required dependency is not installed."
+OCR_FAILED="OCR failed"
+
+ACTION=""
+GEOMETRY=""
+CROP_GEOMETRY=""
+MODE="copy"
+EDITOR=""
+OUTPUT_FILE=""
+SOURCE_FILE=""
+KEEP_SOURCE=false
+FROZEN_SOURCE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --action) ACTION="$2"; shift 2 ;;
+        --geometry) GEOMETRY="$2"; shift 2 ;;
+        --crop-geometry) CROP_GEOMETRY="$2"; shift 2 ;;
+        --mode) MODE="$2"; shift 2 ;;
+        --editor) EDITOR="$2"; shift 2 ;;
+        --output) OUTPUT_FILE="$2"; shift 2 ;;
+        --source) SOURCE_FILE="$2"; shift 2 ;;
+        --frozen-source) FROZEN_SOURCE="$2"; shift 2 ;;
+        --keep-source) KEEP_SOURCE=true; shift ;;
+        --no-notify) NOTIFY_FLAG=0; shift ;;
+        --notify-app) NOTIFY_APP="$2"; shift 2 ;;
+        --copied-title) COPIED_TITLE="$2"; shift 2 ;;
+        --copied-body) COPIED_BODY="$2"; shift 2 ;;
+        --saved-title) SAVED_TITLE="$2"; shift 2 ;;
+        --ocr-done-title) OCR_DONE_TITLE="$2"; shift 2 ;;
+        --ocr-copied-body) OCR_COPIED_BODY="$2"; shift 2 ;;
+        --ocr-empty-body) OCR_EMPTY_BODY="$2"; shift 2 ;;
+        --dep-missing) DEP_MISSING="$2"; shift 2 ;;
+        --ocr-failed) OCR_FAILED="$2"; shift 2 ;;
+        *) exit 1 ;;
+    esac
+done
+
+success_notify() {
+    if [[ "$NOTIFY_FLAG" -eq 1 ]] && command -v notify-send &>/dev/null; then
+        notify-send -a "$NOTIFY_APP" "$1" "$2" & disown
+    fi
+}
+
+require_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        if command -v notify-send &>/dev/null; then
+            notify-send -a "$NOTIFY_APP" "$OCR_FAILED" "$DEP_MISSING"
+        fi
+        exit 1
+    fi
+}
+
+crop_or_grim() {
+    local out="$1" stream="$2"
+
+    if [[ -n "$FROZEN_SOURCE" && -f "$FROZEN_SOURCE" ]]; then
+        if command -v magick &>/dev/null; then
+            if [[ "$stream" == "yes" ]]; then magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage png:-
+            else magick "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "$out"; fi
+        elif command -v convert &>/dev/null; then
+            if [[ "$stream" == "yes" ]]; then convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage png:-
+            else convert "$FROZEN_SOURCE" -crop "$CROP_GEOMETRY" +repage "$out"; fi
+        else
+            if [[ "$stream" == "yes" ]]; then grim -g "$GEOMETRY" -
+            else grim -g "$GEOMETRY" "$out"; fi
+        fi
+        rm -f "$FROZEN_SOURCE"
+    else
+        if [[ "$stream" == "yes" ]]; then grim -g "$GEOMETRY" -
+        else grim -g "$GEOMETRY" "$out"; fi
+    fi
+}
+
+case "$ACTION" in
+    screenshot)
+        require_cmd grim
+        require_cmd wl-copy
+
+        if [[ "$MODE" == "copy" ]]; then
+            crop_or_grim "" "yes" | wl-copy --type image/png
+            success_notify "$COPIED_TITLE" "$COPIED_BODY"
+        elif [[ "$MODE" == "edit" ]]; then
+            mkdir -p "$(dirname "$SOURCE_FILE")"
+            crop_or_grim "$SOURCE_FILE" ""
+
+            if [[ "$EDITOR" == "satty" ]]; then
+                satty --filename "$SOURCE_FILE" --output-filename "$OUTPUT_FILE"
+            else
+                "$EDITOR" -f "$SOURCE_FILE" -o "$OUTPUT_FILE"
+            fi
+
+            if [[ "$KEEP_SOURCE" != "true" ]]; then
+                rm -f "$SOURCE_FILE"
+            fi
+            success_notify "$SAVED_TITLE" "$OUTPUT_FILE"
+        fi
+        ;;
+
+    ocr)
+        require_cmd grim
+        require_cmd tesseract
+        require_cmd wl-copy
+
+        tmp="/tmp/screen-ocr-$$.png"
+        crop_or_grim "$tmp" ""
+        text=""
+        if [[ -s "$tmp" ]]; then
+            text=$(tesseract "$tmp" stdout 2>/dev/null) || true
+        fi
+        rm -f "$tmp"
+
+        if [[ -n "$text" ]]; then
+            printf "%s" "$text" | wl-copy
+            success_notify "$OCR_DONE_TITLE" "$OCR_COPIED_BODY"
+        else
+            success_notify "$OCR_DONE_TITLE" "$OCR_EMPTY_BODY"
+        fi
+        ;;
+
+    search)
+        require_cmd grim
+
+        tmp="/tmp/screen-search-$$.png"
+        crop_or_grim "$tmp" ""
+
+        if [[ -s "$tmp" ]]; then
+            url=$(curl -sF "files[]=@$tmp" https://uguu.se/upload | jq -r '.files[0].url') || true
+            if [[ -n "$url" ]]; then
+                xdg-open "https://lens.google.com/uploadbyurl?url=$url"
+            fi
+        fi
+        rm -f "$tmp"
+        ;;
+esac

--- a/screen-shot-and-record/i18n/de.json
+++ b/screen-shot-and-record/i18n/de.json
@@ -18,7 +18,8 @@
     },
     "enableWindowsSelection": {
       "label": "Fenstererkennung aktivieren",
-      "description": "Erlaubt das Anklicken von Fenstern zur automatischen Regionsauswahl auf unterstutzten Compositors."
+      "description": "Erlaubt das Anklicken von Fenstern zur automatischen Regionsauswahl auf unterstutzten Compositors.",
+      "niriWarning": "Niri-Benutzer: Siehe README für Voraussetzungen und Einschränkungen der Fenstererkennung."
     },
     "screenshotEditor": {
       "label": "Tool zum Bearbeiten von Screenshots",
@@ -36,6 +37,10 @@
       "label": "Speicherordner für Aufnahmen",
       "description": "Ordner, in dem Bildschirmaufnahmen gespeichert werden."
     },
+    "notificationsEnabled": {
+      "label": "Benachrichtigungen aktivieren",
+      "description": "Erfolgsbenachrichtigungen für Screenshots, OCR und Aufnahmen anzeigen. Fehlende Abhängigkeiten werden immer gemeldet."
+    },
     "recordingNotifications": {
       "label": "Aufnahme-Benachrichtigungen",
       "description": "Benachrichtigungen anzeigen, wenn eine Aufnahme startet/stoppt oder Fehler auftreten."
@@ -51,8 +56,7 @@
       "failed": "Screenshot fehlgeschlagen",
       "savedTitle": "Screenshot gespeichert",
       "copiedTitle": "Screenshot kopiert",
-      "copiedBody": "Bild in die Zwischenablage kopiert",
-      "niriNotSupported": "Niri wird für Screenshots nicht unterstützt."
+      "copiedBody": "Bild in die Zwischenablage kopiert"
     },
     "search": {
       "failed": "Bildersuche fehlgeschlagen"

--- a/screen-shot-and-record/i18n/de.json
+++ b/screen-shot-and-record/i18n/de.json
@@ -37,6 +37,10 @@
       "label": "Speicherordner für Aufnahmen",
       "description": "Ordner, in dem Bildschirmaufnahmen gespeichert werden."
     },
+    "pngCompressionLevel": {
+      "label": "PNG-Komprimierungsstufe",
+      "description": "PNG-Komprimierungsstufe (0=unkomprimiert, 1=Standard, 9=maximal). Höhere Werte verlangsamen Screenshots, erzeugen aber kleinere Dateien; niedrigere Werte vergrößern die PNG-Datei und können das Kopieren verhindern."
+    },
     "notificationsEnabled": {
       "label": "Benachrichtigungen aktivieren",
       "description": "Erfolgsbenachrichtigungen für Screenshots, OCR und Aufnahmen anzeigen. Fehlende Abhängigkeiten werden immer gemeldet."

--- a/screen-shot-and-record/i18n/en.json
+++ b/screen-shot-and-record/i18n/en.json
@@ -18,7 +18,8 @@
         },
         "enableWindowsSelection": {
             "label": "Enable Window Detection",
-            "description": "Allow clicking windows to auto-select their region on supported compositors."
+            "description": "Allow clicking windows to auto-select their region on supported compositors.",
+            "niriWarning": "Niri users: see README for prerequisites and limitations of window detection."
         },
         "screenshotEditor": {
             "label": "Screenshot Annotation Tool",
@@ -36,6 +37,10 @@
             "label": "Recording Save Folder",
             "description": "Folder where screen recordings are saved."
         },
+        "notificationsEnabled": {
+            "label": "Enable Notifications",
+            "description": "Show success notifications for screenshots, OCR, and recording. Dependency missing alerts are always shown."
+        },
         "recordingNotifications": {
             "label": "Recording Notifications",
             "description": "Show notifications when recording starts/stops or errors occur."
@@ -51,8 +56,7 @@
             "failed": "Screenshot failed",
             "savedTitle": "Screenshot saved",
             "copiedTitle": "Screenshot copied",
-            "copiedBody": "Image copied to clipboard",
-            "niriNotSupported": "Niri is not supported for screenshots."
+            "copiedBody": "Image copied to clipboard"
         },
         "search": {
             "failed": "Image search failed"

--- a/screen-shot-and-record/i18n/en.json
+++ b/screen-shot-and-record/i18n/en.json
@@ -37,6 +37,10 @@
             "label": "Recording Save Folder",
             "description": "Folder where screen recordings are saved."
         },
+        "pngCompressionLevel": {
+            "label": "PNG Compression Level",
+            "description": "PNG compression level (0=uncompressed, 1=default, 9=maximum). Higher values slow down screenshots but reduce file size; lower values bloat PNG size and may cause clipboard copy failures."
+        },
         "notificationsEnabled": {
             "label": "Enable Notifications",
             "description": "Show success notifications for screenshots, OCR, and recording. Dependency missing alerts are always shown."

--- a/screen-shot-and-record/i18n/es.json
+++ b/screen-shot-and-record/i18n/es.json
@@ -18,7 +18,8 @@
         },
         "enableWindowsSelection": {
             "label": "Activar deteccion de ventanas",
-            "description": "Permite hacer clic en ventanas para seleccionar automaticamente su region en compositores compatibles."
+            "description": "Permite hacer clic en ventanas para seleccionar automaticamente su region en compositores compatibles.",
+            "niriWarning": "Usuarios de Niri: consulte el README para conocer los requisitos previos y limitaciones de la deteccion de ventanas."
         },
         "screenshotEditor": {
             "label": "Herramienta de Anotación de Capturas",
@@ -36,6 +37,10 @@
             "label": "Carpeta de guardado de grabaciones",
             "description": "Carpeta donde se guardan las grabaciones de pantalla."
         },
+        "notificationsEnabled": {
+            "label": "Activar notificaciones",
+            "description": "Mostrar notificaciones de éxito para capturas, OCR y grabación. Las alertas de dependencias faltantes siempre se muestran."
+        },
         "recordingNotifications": {
             "label": "Notificaciones de grabación",
             "description": "Mostrar notificaciones al iniciar/detener la grabación o cuando ocurren errores."
@@ -51,8 +56,7 @@
             "failed": "La captura falló",
             "savedTitle": "Captura guardada",
             "copiedTitle": "Captura copiada",
-            "copiedBody": "Imagen copiada al portapapeles",
-            "niriNotSupported": "Niri no es compatible con capturas de pantalla."
+            "copiedBody": "Imagen copiada al portapapeles"
         },
         "search": {
             "failed": "La búsqueda de imágenes falló"

--- a/screen-shot-and-record/i18n/es.json
+++ b/screen-shot-and-record/i18n/es.json
@@ -37,6 +37,10 @@
             "label": "Carpeta de guardado de grabaciones",
             "description": "Carpeta donde se guardan las grabaciones de pantalla."
         },
+        "pngCompressionLevel": {
+            "label": "Nivel de compresion PNG",
+            "description": "Nivel de compresión PNG (0=sin comprimir, 1=predeterminado, 9=máximo). Valores altos ralentizan la captura pero reducen el tamaño; valores bajos aumentan el tamaño PNG y pueden impedir copiar al portapapeles."
+        },
         "notificationsEnabled": {
             "label": "Activar notificaciones",
             "description": "Mostrar notificaciones de éxito para capturas, OCR y grabación. Las alertas de dependencias faltantes siempre se muestran."

--- a/screen-shot-and-record/i18n/zh-CN.json
+++ b/screen-shot-and-record/i18n/zh-CN.json
@@ -37,6 +37,10 @@
             "label": "录屏保存文件夹",
             "description": "屏幕录制文件将保存到此文件夹。"
         },
+        "pngCompressionLevel": {
+            "label": "PNG 压缩级别",
+            "description": "PNG 压缩级别（0=无压缩，1=默认，9=最大）。数值越高截图越慢但文件越小；数值越低 PNG 体积越大，可能导致复制失败。"
+        },
         "notificationsEnabled": {
             "label": "启用通知",
             "description": "显示截图、OCR 和录屏的成功通知。缺少依赖的提示始终显示。"

--- a/screen-shot-and-record/i18n/zh-CN.json
+++ b/screen-shot-and-record/i18n/zh-CN.json
@@ -18,7 +18,8 @@
         },
         "enableWindowsSelection": {
             "label": "启用窗口检测",
-            "description": "在支持的合成器上，允许点击窗口自动选择其区域。"
+            "description": "在支持的合成器上，允许点击窗口自动选择其区域。",
+            "niriWarning": "Niri 用户请查看 README 了解窗口检测的前提条件和限制。"
         },
         "screenshotEditor": {
             "label": "截图标注工具",
@@ -36,6 +37,10 @@
             "label": "录屏保存文件夹",
             "description": "屏幕录制文件将保存到此文件夹。"
         },
+        "notificationsEnabled": {
+            "label": "启用通知",
+            "description": "显示截图、OCR 和录屏的成功通知。缺少依赖的提示始终显示。"
+        },
         "recordingNotifications": {
             "label": "录屏通知",
             "description": "在开始/停止录屏或发生错误时显示通知。"
@@ -51,8 +56,7 @@
             "failed": "截图失败",
             "savedTitle": "截图已保存",
             "copiedTitle": "截图已复制",
-            "copiedBody": "图像已复制到剪贴板",
-            "niriNotSupported": "Niri 不支持屏幕截图。"
+            "copiedBody": "图像已复制到剪贴板"
         },
         "search": {
             "failed": "图像搜索失败"

--- a/screen-shot-and-record/manifest.json
+++ b/screen-shot-and-record/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screen-shot-and-record",
   "name": "ScreenShot & Record",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minNoctaliaVersion": "3.6.0",
   "author": "Pulsar",
   "license": "GPL-3.0-or-later",

--- a/screen-shot-and-record/manifest.json
+++ b/screen-shot-and-record/manifest.json
@@ -6,12 +6,13 @@
   "author": "Pulsar",
   "license": "GPL-3.0-or-later",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
-  "description": "A screenshot plugin with OCR, Google Lens integration, and screen recording. Supports Sway, Hyprland and MangoWM.",
+  "description": "A screenshot plugin with OCR, Google Lens integration, and screen recording. Supports Niri, Hyprland, Sway and MangoWM.",
   "tags": [
     "Bar",
     "Panel",
     "Utility",
-     "Hyprland",
+    "Niri",
+    "Hyprland",
     "Sway"
   ],
   "entryPoints": {
@@ -31,7 +32,8 @@
       "keepSourceScreenshot": false,
       "savePath": "~/Pictures/Screenshots",
       "recordingSavePath": "~/Videos",
-      "recordingNotifications": true
+      "recordingNotifications": true,
+      "notificationsEnabled": true
     }
   }
 }

--- a/screen-shot-and-record/manifest.json
+++ b/screen-shot-and-record/manifest.json
@@ -25,11 +25,12 @@
     "plugins": []
   },
   "metadata": {
-   "defaultSettings": {
+    "defaultSettings": {
       "enableCross": true,
       "enableWindowsSelection": true,
       "screenshotEditor": "swappy",
       "keepSourceScreenshot": false,
+      "pngCompressionLevel": 1,
       "savePath": "~/Pictures/Screenshots",
       "recordingSavePath": "~/Videos",
       "recordingNotifications": true,


### PR DESCRIPTION
> ~~I'm back!~~

## Summary

This PR:
1. Fixes a long-standing issue where this plugin could not be used properly on Niri (as it would probabilistically cause noctalia-shell to crash).
The root cause can be traced back to the Qt library, so I cannot fix it. I used grim to capture "bare" screenshots (ppm) and then display them.
This approach even brings faster speed and higher screenshot consistency (you are capturing an image directly, rather than a potentially inconsistent frozen layer), achieving three benefits at once.
2. Added window selection functionality for Niri.
Please note that using this feature has certain prerequisites and limitations, which have been documented in the README and are prompted for reading in the settings interface.
Here is also reiterated:
   1. Window detection requires Niri with [PR #3305](https://github.com/YaLTeR/niri/pull/3305) (not yet merged).
   2. Due to f64 rounding in the PR, window borders may have up to 1px of offset.
   3. Niri builds without `window-geometries` (from #3305) will silently disable window detection — screenshot capture still works normally.
3. Allow silencing most notifications (failure notifications still take effect), and extract the main logic of the screenshot command into a bash script.
4. Allow users to customize the PNG compression level to balance between higher speed and smaller file size.
5. Countless minor tweaks.

## Tests
Already tested under Niri and Hyprland.
Due to device limitations, multi-monitor testing is not possible; testing is welcome.

## Other
Sincere thanks to @Mathew-D for the tremendous contributions during my absence. Without you, my work today would have required much more effort.