### PR TITLE
feat(niri-screensaver): update to 0.8.0

### DIFF
--- a/niri-screensaver/Main.qml
+++ b/niri-screensaver/Main.qml
@@ -126,6 +126,7 @@ Item {
       "NOW_PLAYING_DURATION=\"" + _shEscape(s.nowPlayingDuration || 3) + "\"",
       "LOGO_FILE=\"" + _shEscape(s.logoPath) + "\"",
       "CURSOR_HIDE=\"" + bool(s.cursorHide) + "\"",
+      "CURSOR_WARP=\"" + bool(s.cursorWarp) + "\"",
       "DISMISS_ON_KEY=\"" + bool(s.dismissOnKey) + "\"",
       "RANDOM_LOGO=\"" + bool(s.randomLogo) + "\"",
       "LOGO_DIR=\"" + _shEscape(s.logoDir) + "\"",

--- a/niri-screensaver/README.md
+++ b/niri-screensaver/README.md
@@ -89,7 +89,7 @@ installed `share/logos/`) and auto-refreshes when files appear or
 disappear; the fade lists come from `niri-screensaver-ctl effects`.
 
 Settings not surfaced in the UI (`FRAME_RATE`, `CLOCK_DURATION`,
-`CLOCK_FONT`, `CURSOR_HIDE`, `DISMISS_ON_KEY`) can be edited directly in
+`CLOCK_FONT`, `CURSOR_HIDE`, `CURSOR_WARP`, `DISMISS_ON_KEY`) can be edited directly in
 `~/.config/niri-screensaver/config` — they round-trip through the plugin on
 next reload.
 

--- a/niri-screensaver/manifest.json
+++ b/niri-screensaver/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "niri-screensaver",
   "name": "Niri Screensaver",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "minNoctaliaVersion": "4.7.0",
   "author": "jfreed-dev",
   "license": "GPL-3.0-only",
@@ -34,6 +34,7 @@
       "nowPlayingDuration": 3,
       "logoPath": "",
       "cursorHide": true,
+      "cursorWarp": false,
       "dismissOnKey": true,
       "randomLogo": false,
       "logoDir": "",


### PR DESCRIPTION
Updates the `niri-screensaver` plugin to **0.8.0** ([upstream release](https://github.com/jfreed-dev/niri-screensaver/releases/tag/v0.8.0)). Follows the merged 0.7.0 update (#933).

**Plugin-surface diff:** manifest version string, one new `defaultSettings` key `cursorWarp` (default `false`) with the matching one-line addition to `Main.qml`'s config writer, and a README list update. No settings UI, i18n, or asset changes.

**What 0.8.0 fixes upstream:** the launcher's post-launch pointer warp injected virtual-pointer motion that niri reports to `ext-idle-notify-v1` as activity, resetting every Noctalia idle timer on each launch, so idle stages longer than the screensaver threshold (lock, screen off) could never fire. Pointer parking is now opt-in via `cursorWarp`/`CURSOR_WARP`, and a default launch generates no idle activity.

`registry.json` is intentionally untouched (auto-generated post-merge).
