### PR TITLE
cloudflare-warp: fix ToS flag, fix mode display, add mode switcher

### DIFF
--- a/cloudflare-warp/Main.qml
+++ b/cloudflare-warp/Main.qml
@@ -16,6 +16,7 @@ Item {
   property string warpMode: ""
   property bool isRefreshing: false
   property bool isSwitchingMode: false
+  property bool modeSwitchLocked: false
   property string lastToggleAction: ""
 
   readonly property var availableModes: [
@@ -136,6 +137,7 @@ Item {
         try {
           var data = JSON.parse(output)
           root.warpMode = data?.settings?.operation_mode ?? ""
+          root.modeSwitchLocked = data?.settings?.switch_locked ?? false
         } catch (e) {
           Logger.w("CloudflareWarp", "Failed to parse warp-cli settings JSON: " + e)
           root.warpMode = ""
@@ -143,6 +145,7 @@ Item {
       } else {
         Logger.w("CloudflareWarp", "warp-cli settings failed: " + String(modeProcess.stderr.text || "").trim())
       }
+      root.isRefreshing = false
     }
   }
 

--- a/cloudflare-warp/Main.qml
+++ b/cloudflare-warp/Main.qml
@@ -15,7 +15,12 @@ Item {
   property bool warpConnected: false
   property string warpMode: ""
   property bool isRefreshing: false
+  property bool isSwitchingMode: false
   property string lastToggleAction: ""
+
+  readonly property var availableModes: [
+    "warp", "doh", "warp+doh", "dot", "warp+dot", "proxy", "tunnel_only"
+  ]
 
   Timer {
     id: updateTimer
@@ -45,6 +50,15 @@ Item {
     if (root.isRefreshing) return
     root.isRefreshing = true
     statusProcess.running = true
+    modeProcess.running = true
+  }
+
+  function setMode(mode) {
+    if (root.isSwitchingMode) return
+    if (root.availableModes.indexOf(mode) === -1) return
+    root.isSwitchingMode = true
+    modeSetProcess.command = ["warp-cli", "--accept-tos", "mode", mode]
+    modeSetProcess.running = true
   }
 
   function connect() {
@@ -85,7 +99,7 @@ Item {
 
   Process {
     id: statusProcess
-    command: ["warp-cli", "status"]
+    command: ["warp-cli", "--accept-tos", "status"]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 
@@ -101,16 +115,8 @@ Item {
         } else {
           root.warpConnected = false
         }
-
-        var modeMatch = output.match(/[Dd]aemon [Mm]ode:\s*(\S+)/)
-        if (modeMatch) {
-          root.warpMode = modeMatch[1]
-        } else {
-          root.warpMode = ""
-        }
       } else {
         root.warpConnected = false
-        root.warpMode = ""
         if (exitCode !== 0) {
           Logger.w("CloudflareWarp", "warp-cli status failed: " + String(statusProcess.stderr.text || "").trim())
         }
@@ -119,8 +125,52 @@ Item {
   }
 
   Process {
+    id: modeProcess
+    command: ["warp-cli", "--accept-tos", "--json", "settings"]
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+
+    onExited: function(exitCode) {
+      var output = String(modeProcess.stdout.text || "").trim()
+      if (exitCode === 0 && output) {
+        try {
+          var data = JSON.parse(output)
+          root.warpMode = data?.settings?.operation_mode ?? ""
+        } catch (e) {
+          Logger.w("CloudflareWarp", "Failed to parse warp-cli settings JSON: " + e)
+          root.warpMode = ""
+        }
+      } else {
+        Logger.w("CloudflareWarp", "warp-cli settings failed: " + String(modeProcess.stderr.text || "").trim())
+      }
+    }
+  }
+
+  Process {
+    id: modeSetProcess
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+
+    onExited: function(exitCode) {
+      root.isSwitchingMode = false
+      if (exitCode === 0) {
+        ToastService.showNotice(
+          pluginApi?.tr("toast.title"),
+          pluginApi?.tr("toast.mode-changed"),
+          "cloud-lock"
+        )
+      } else {
+        var err = String(modeSetProcess.stderr.text || "").trim()
+        Logger.e("CloudflareWarp", "Mode switch failed: " + err)
+        ToastService.showWarning(pluginApi?.tr("toast.title"), err || "Mode switch failed")
+      }
+      statusDelayTimer.start()
+    }
+  }
+
+  Process {
     id: connectProcess
-    command: ["warp-cli", "connect"]
+    command: ["warp-cli", "--accept-tos", "connect"]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 
@@ -142,7 +192,7 @@ Item {
 
   Process {
     id: disconnectProcess
-    command: ["warp-cli", "disconnect"]
+    command: ["warp-cli", "--accept-tos", "disconnect"]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 

--- a/cloudflare-warp/Panel.qml
+++ b/cloudflare-warp/Panel.qml
@@ -87,7 +87,7 @@ Item {
             minimumWidth: 340
             popupHeight: 260
             visible: mainInstance?.warpInstalled ?? false
-            enabled: !(mainInstance?.isSwitchingMode ?? false)
+            enabled: !(mainInstance?.isSwitchingMode ?? false) && !(mainInstance?.modeSwitchLocked ?? false)
             model: [
               { key: "warp", name: pluginApi?.tr("modes.warp") },
               { key: "doh", name: pluginApi?.tr("modes.doh") },

--- a/cloudflare-warp/Panel.qml
+++ b/cloudflare-warp/Panel.qml
@@ -14,7 +14,7 @@ Item {
 
   readonly property var mainInstance: pluginApi?.mainInstance
 
-  property real contentPreferredWidth: 300 * Style.uiScaleRatio
+  property real contentPreferredWidth: 420 * Style.uiScaleRatio
   property real contentPreferredHeight: contentColumn.implicitHeight + Style.marginM * 2
 
   anchors.fill: parent
@@ -74,22 +74,34 @@ Item {
             }
           }
 
-          RowLayout {
+          NText {
+            visible: mainInstance?.warpInstalled ?? false
+            text: pluginApi?.tr("panel.mode") + ":"
+            pointSize: Style.fontSizeS
+            font.weight: Style.fontWeightSemiBold
+            color: Color.mOnSurfaceVariant
+          }
+
+          NComboBox {
             Layout.fillWidth: true
-            visible: (mainInstance?.warpMode ?? "") !== ""
-            spacing: Style.marginS
+            minimumWidth: 340
+            popupHeight: 260
+            visible: mainInstance?.warpInstalled ?? false
+            enabled: !(mainInstance?.isSwitchingMode ?? false)
+            model: [
+              { key: "warp", name: pluginApi?.tr("modes.warp") },
+              { key: "doh", name: pluginApi?.tr("modes.doh") },
+              { key: "warp+doh", name: pluginApi?.tr("modes.warp_doh") },
+              { key: "dot", name: pluginApi?.tr("modes.dot") },
+              { key: "warp+dot", name: pluginApi?.tr("modes.warp_dot") },
+              { key: "proxy", name: pluginApi?.tr("modes.proxy") },
+              { key: "tunnel_only", name: pluginApi?.tr("modes.tunnel_only") }
+            ]
+            currentKey: mainInstance?.warpMode ?? ""
+            placeholder: pluginApi?.tr("panel.mode")
 
-            NText {
-              text: pluginApi?.tr("panel.mode") + ":"
-              pointSize: Style.fontSizeS
-              color: Color.mOnSurfaceVariant
-            }
-
-            NText {
-              text: mainInstance?.warpMode ?? ""
-              pointSize: Style.fontSizeS
-              color: Color.mOnSurface
-              font.family: Settings.data.ui.fontFixed
+            onSelected: key => {
+              mainInstance?.setMode(key)
             }
           }
 

--- a/cloudflare-warp/i18n/en.json
+++ b/cloudflare-warp/i18n/en.json
@@ -15,6 +15,15 @@
     "mode": "Mode",
     "not-installed": "warp-cli not found. Install Cloudflare WARP to use this plugin."
   },
+  "modes": {
+    "warp": "WARP (full VPN)",
+    "doh": "DNS over HTTPS only",
+    "warp_doh": "WARP + DNS over HTTPS",
+    "dot": "DNS over TLS only",
+    "warp_dot": "WARP + DNS over TLS",
+    "proxy": "SOCKS5 proxy",
+    "tunnel_only": "Tunnel only (no DNS proxy)"
+  },
   "settings": {
     "title": "Cloudflare WARP",
     "description": "Toggle Cloudflare WARP from the bar and customize how it looks.",
@@ -28,6 +37,7 @@
   "toast": {
     "title": "Cloudflare WARP",
     "connected": "Connected to WARP",
-    "disconnected": "Disconnected from WARP"
+    "disconnected": "Disconnected from WARP",
+    "mode-changed": "Mode switched"
   }
 }

--- a/cloudflare-warp/i18n/ru.json
+++ b/cloudflare-warp/i18n/ru.json
@@ -15,6 +15,15 @@
     "mode": "Режим",
     "not-installed": "warp-cli не найден. Установите Cloudflare WARP для использования этого плагина."
   },
+  "modes": {
+    "warp": "WARP (полный VPN)",
+    "doh": "Только DNS over HTTPS",
+    "warp_doh": "WARP + DNS over HTTPS",
+    "dot": "Только DNS over TLS",
+    "warp_dot": "WARP + DNS over TLS",
+    "proxy": "SOCKS5-прокси",
+    "tunnel_only": "Только туннель (без DNS-прокси)"
+  },
   "settings": {
     "title": "Cloudflare WARP",
     "description": "Включайте и отключайте Cloudflare WARP с панели и настраивайте внешний вид.",
@@ -28,6 +37,7 @@
   "toast": {
     "title": "Cloudflare WARP",
     "connected": "Подключено к WARP",
-    "disconnected": "Отключено от WARP"
+    "disconnected": "Отключено от WARP",
+    "mode-changed": "Режим изменён"
   }
 }


### PR DESCRIPTION
## Problem

`warp-cli` refuses every command with *"Please accept the WARP Terms of Service by running this command in a TTY or by passing the --accept-tos flag"* when it isn't run in a TTY. QuickShell's `Process` always runs non-interactively, so `status`, `connect`, and `disconnect` were silently failing on every single invocation — the widget could never show a correct connected state, and clicking connect/disconnect did nothing but log a warning.

The mode display was also dead code: it tried to regex-match a `Daemon Mode:` line out of `warp-cli status` output, but that line doesn't exist in the actual output, so `warpMode` was always an empty string and the mode row never rendered.

## Changes

- Add `--accept-tos` to all `warp-cli` invocations (`status`, `connect`, `disconnect`).
- Fetch the current mode from `warp-cli --json settings` (`operation_mode` field) instead of parsing nonexistent text output.
- Add a mode switcher: a dropdown in the panel covering all `warp-cli mode` values (`warp`, `doh`, `warp+doh`, `dot`, `warp+dot`, `proxy`, `tunnel_only`), calling `warp-cli mode <mode>` on selection.
- Widen the panel (300 → 420) and the mode combo box (min-width 340) so the longer mode names aren't clipped.
- Add `en`/`ru` translations for the new mode names and a "mode changed" toast.

## Testing

Manually exercised the full cycle (`status` → `disconnect` → `status` → `connect` → `status`, plus `mode doh`/`mode warp` switches) via the same `warp-cli` invocations the plugin now uses, confirmed against `qs -c noctalia-shell log` that the plugin loads and refreshes with no warnings/errors.